### PR TITLE
[Bug Fix] Apply width on cell component based on it's columns width

### DIFF
--- a/addon/components/lt-cell.js
+++ b/addon/components/lt-cell.js
@@ -10,6 +10,7 @@ export default Ember.Component.extend({
   layout,
   tagName: 'td',
   classNames: ['lt-cell'],
+  attributeBindings: ['width'],
   classNameBindings: ['align', 'isSorted'],
 
   column: null,
@@ -20,7 +21,9 @@ export default Ember.Component.extend({
     return `align-${this.get('column.align')}`;
   }),
 
-  isSorted: computed.oneWay('column.sorted'),
+  isSorted: computed.readOnly('column.sorted'),
+
+  width: computed.readOnly('column.width'),
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
Right now when you leave out `{{t.head}}`, the table does not keep it's width per column, since they are only defined on the `thead`. With those changes it will always have the correct width.