### PR TITLE
Using native Ember trackpad scroll emulator

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -37,11 +37,14 @@
 .ember-light-table .lt-body-wrap {
   display: flex;
   flex-direction: column;
+
+  flex: 1 0 auto;
 }
 
 .ember-light-table .lt-scrollable {
   width: 100%;
-  height: 100%;
+
+  flex: 1 0 auto;
 }
 
 .ember-light-table .align-left {

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -35,7 +35,6 @@
 }
 
 .ember-light-table .lt-body-wrap {
-  flex: 1 0 auto;
   display: flex;
   flex-direction: column;
 }

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -2,7 +2,7 @@
 
 {{#lt-scrollable
   autoHide=autoHideScrollbar
-  scrollEnd="onScrolledToBottom"
+  onScrolledToBottom="onScrolledToBottom"
   scrollBuffer=scrollBuffer
   as |scrollbar|
 }}

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "ember-truth-helpers": "1.2.0",
     "ember-try": "0.2.2",
     "loader.js": "^4.0.1",
-    "yuidoc-ember-theme": "offirgolan/yuidoc-ember-theme",
-    "ember-scrollable": "taras/ember-scrollable#d57694c5f63cc2aa1cec9931f28dd6499efa2a13"
+    "yuidoc-ember-theme": "offirgolan/yuidoc-ember-theme"
   },
   "keywords": [
     "ember-addon",
@@ -60,10 +59,8 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-wormhole": "0.4.0",
-    "ember-composable-helpers": "0.26.1"
-  },
-  "peerDependencies": {
-    "ember-scrollable": "taras/ember-scrollable#d57694c5f63cc2aa1cec9931f28dd6499efa2a13"
+    "ember-composable-helpers": "0.26.1",
+    "ember-scrollable": "alphasights/ember-scrollable#0.2.3"    
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-wormhole": "0.4.0",
     "ember-composable-helpers": "0.26.1",
-    "ember-scrollable": "alphasights/ember-scrollable#0.2.3"    
+    "ember-scrollable": "alphasights/ember-scrollable#0.2.4"    
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -19,14 +19,14 @@ test('it renders', function(assert) {
   assert.equal(this.$().text().trim(), '');
 });
 
-// TODO: Figure out why this test fails in Phantomjs
+// TODO: Figure out why tests is failing in Phantom.js
 // test('scrolled to bottom', function(assert) {
 //   assert.expect(4);
 //   let done = assert.async();
 
 //   this.set('table', new Table(Columns, createUsers(50)));
 
-//   this.on('onScrolledToBottom', () => { assert.ok(true); });
+//   this.on('onScrolledToBottom', () => { assert.ok(true); done(); });
 
 //   this.render(hbs`
 //     {{#light-table table height='40vh' as |t|}}
@@ -47,7 +47,6 @@ test('it renders', function(assert) {
 //     scrollTop: scrollHeight
 //   }, 0);
 
-//   Ember.run.later(done, 1500);
 // });
 
 

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -107,7 +107,7 @@ test('table assumes height of container', function(assert){
 
 });
 
-// TODO: figure out why this test doesn't work properly in Phantomjs
+//TODO: figure out why this test doesn't work properly in Phantomjs
 // test('table body should consume all available space when not enough content to fill it', function(assert){
 //   assert.expect(3);
 
@@ -127,7 +127,7 @@ test('table assumes height of container', function(assert){
 //   `);
 
 //   assert.equal(this.$('.lt-head-wrap').height(), 42, 'header is 42px tall');
-//   assert.equal(this.$('.lt-body-wrap').height(), 416, 'body is 418px tall');
-//   assert.equal(this.$('.lt-foot-wrap').height(), 42, 'header is 42px tall');
+//   assert.equal(this.$('.lt-body-wrap').height(), 438, 'body is 438px tall');
+//   assert.equal(this.$('.lt-foot-wrap').height(), 20, 'header is 20px tall');
 
 // });


### PR DESCRIPTION
Using a version of ember-scroll that's rewritten without dependency on trackpad-scroll-emulator jQuery Plugin.