### PR TITLE
Support templates in column and cell types

### DIFF
--- a/addon/components/cells/base.js
+++ b/addon/components/cells/base.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import layout from 'ember-light-table/templates/components/cells/base';
 
 const {
   computed
@@ -10,7 +9,6 @@ const {
  * @class Base Cell
  */
 const Cell = Ember.Component.extend({
-  layout,
   tagName: 'td',
   classNames: ['lt-cell'],
   attributeBindings: ['width'],

--- a/addon/components/columns/base.js
+++ b/addon/components/columns/base.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import layout from 'ember-light-table/templates/components/columns/base';
 
 const {
   isEmpty,
@@ -11,7 +10,6 @@ const {
  * @class Base Column
  */
 const Column = Ember.Component.extend({
-  layout,
   tagName: 'th',
   classNames: ['lt-column'],
   attributeBindings: ['width', 'colspan', 'rowspan'],

--- a/addon/templates/components/cells/base.hbs
+++ b/addon/templates/components/cells/base.hbs
@@ -1,5 +1,0 @@
-{{#if column.cellComponent}}
-  {{component column.cellComponent tableActions=tableActions column=column row=row value=value}}
-{{else}}
-  {{value}}
-{{/if}}

--- a/addon/templates/components/columns/base.hbs
+++ b/addon/templates/components/columns/base.hbs
@@ -1,8 +1,0 @@
-{{#if column.component}}
-  {{component column.component column=column table=table tableActions=tableActions sortIcons=sortIcons}}
-{{else}}
-  {{column.label}}
-  {{#if column.sorted}}
-    <span class="lt-sort-icon {{if column.ascending sortIcons.iconAscending sortIcons.iconDescending}}"></span>
-  {{/if}}
-{{/if}}

--- a/addon/templates/components/lt-foot.hbs
+++ b/addon/templates/components/lt-foot.hbs
@@ -6,12 +6,14 @@
       {{else}}
         <tr>
           {{#each columns as |column|}}
-            {{component (concat 'light-table/columns/' column.type) column
+            {{#component (concat 'light-table/columns/' column.type) column
               table=table
               tableActions=tableActions
               sortIcons=sortIcons
               click=(action 'onColumnClick' column)
-              doubleClick=(action 'onColumnDoubleClick' column)}}
+              doubleClick=(action 'onColumnDoubleClick' column) as |_context|}}
+              {{partial 'light-table/-partials/base-column'}}
+            {{/component}}
           {{/each}}
         </tr>
       {{/if}}

--- a/addon/templates/components/lt-head.hbs
+++ b/addon/templates/components/lt-head.hbs
@@ -18,24 +18,28 @@
 
         <tr>
           {{#each columnGroups as |column|}}
-            {{component (concat 'light-table/columns/' column.type) column
+            {{#component (concat 'light-table/columns/' column.type) column
               table=table
               tableActions=tableActions
               sortIcons=sortIcons
               click=(action 'onColumnClick' column)
-              doubleClick=(action 'onColumnDoubleClick' column)}}
+              doubleClick=(action 'onColumnDoubleClick' column) as |_context|}}
+              {{partial 'light-table/-partials/base-column'}}
+            {{/component}}
           {{/each}}
         </tr>
         <tr>
           {{#each subColumns as |column|}}
-            {{component (concat 'light-table/columns/' column.type) column
+            {{#component (concat 'light-table/columns/' column.type) column
               table=table
               rowspan=1
               classNames="lt-sub-column"
               tableActions=tableActions
               sortIcons=sortIcons
               click=(action 'onColumnClick' column)
-              doubleClick=(action 'onColumnDoubleClick' column)}}
+              doubleClick=(action 'onColumnDoubleClick' column) as |_context|}}
+              {{partial 'light-table/-partials/base-column'}}
+            {{/component}}
           {{/each}}
         </tr>
       {{/if}}

--- a/addon/templates/components/lt-row.hbs
+++ b/addon/templates/components/lt-row.hbs
@@ -1,5 +1,7 @@
 {{#each columns as |column|}}
-  {{component (concat 'light-table/cells/' column.cellType) column row
+  {{#component (concat 'light-table/cells/' column.cellType) column row
     rawValue=(get row column.valuePath)
-    tableActions=tableActions}}
+    tableActions=tableActions as |_context|}}
+    {{partial 'light-table/-partials/base-cell'}}
+  {{/component}}
 {{/each}}

--- a/app/templates/components/light-table/cells/base.hbs
+++ b/app/templates/components/light-table/cells/base.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/app/templates/components/light-table/columns/base.hbs
+++ b/app/templates/components/light-table/columns/base.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/app/templates/light-table/-partials/base-cell.hbs
+++ b/app/templates/light-table/-partials/base-cell.hbs
@@ -1,0 +1,9 @@
+{{#if _context.column.cellComponent}}
+  {{component _context.column.cellComponent
+    tableActions=_context.tableActions
+    column=_context.column
+    row=_context.row
+    value=_context.value}}
+{{else}}
+  {{_context.value}}
+{{/if}}

--- a/app/templates/light-table/-partials/base-column.hbs
+++ b/app/templates/light-table/-partials/base-column.hbs
@@ -1,0 +1,12 @@
+{{#if _context.column.component}}
+  {{component _context.column.component
+    column=_context.column
+    table=_context.table
+    tableActions=_context.tableActions
+    sortIcons=_context.sortIcons}}
+{{else}}
+  {{_context.column.label}}
+  {{#if _context.column.sorted}}
+    <span class="lt-sort-icon {{if _context.column.ascending _context.sortIcons.iconAscending _context.sortIcons.iconDescending}}"></span>
+  {{/if}}
+{{/if}}

--- a/blueprints/cell-type/files/app/templates/components/light-table/cells/__name__.hbs
+++ b/blueprints/cell-type/files/app/templates/components/light-table/cells/__name__.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/blueprints/column-type/files/app/templates/components/light-table/columns/__name__.hbs
+++ b/blueprints/column-type/files/app/templates/components/light-table/columns/__name__.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/test-support/helpers/ember-light-table.js
+++ b/test-support/helpers/ember-light-table.js
@@ -1,0 +1,21 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export function renderCell(context, name) {
+  context.set('_cellComponent', `light-table/cells/${name}`);
+
+  context.render(hbs`
+    {{#component _cellComponent column row rawValue=(get row column.valuePath) as |_context|}}
+      {{partial 'light-table/-partials/base-cell'}}
+    {{/component}}
+  `);
+}
+
+export function renderColumn(context, name) {
+  context.set('_columnComponent', `light-table/columns/${name}`);
+
+  context.render(hbs`
+    {{#component _columnComponent column table=table as |_context|}}
+      {{partial 'light-table/-partials/base-column'}}
+    {{/component}}
+  `);
+}

--- a/tests/integration/components/light-table/cells/base-test.js
+++ b/tests/integration/components/light-table/cells/base-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { renderCell } from '../../../../helpers/ember-light-table';
 import { Row, Column} from 'ember-light-table';
 
 moduleForComponent('light-table/cells/base', 'Integration | Component | Cells | base', {
@@ -8,7 +8,7 @@ moduleForComponent('light-table/cells/base', 'Integration | Component | Cells | 
 });
 
 test('it renders', function(assert) {
-  this.render(hbs`{{light-table/cells/base}}`);
+  renderCell(this, 'base');
 
   assert.equal(this.$().text().trim(), '');
 });
@@ -22,9 +22,11 @@ test('cell with column format', function(assert) {
     }
   }));
 
-  this.set('row', new Row());
+  this.set('row', new Row({
+    num: 2
+  }));
 
-  this.render(hbs`{{light-table/cells/base column row rawValue=2}}`);
+  renderCell(this, 'base');
 
   assert.equal(this.$().text().trim(), '4');
 });
@@ -40,7 +42,7 @@ test('cell format with no valuePath', function(assert) {
     num: 2
   }));
 
-  this.render(hbs`{{light-table/cells/base column row}}`);
+  renderCell(this, 'base');
 
   assert.equal(this.$().text().trim(), '4');
 });
@@ -62,7 +64,7 @@ test('cell with nested valuePath', function(assert) {
     }
   }));
 
-  this.render(hbs`{{light-table/cells/base column row rawValue=(get row column.valuePath)}}`);
+  renderCell(this, 'base');
 
   assert.equal(this.$().text().trim(), '4');
 


### PR DESCRIPTION
Resolved #53 

Running `ember g cell-type link-to`

will now create a new template allowing you to do something like this

```hbs
{{#link-to column.route row.id}}
  {{yield this}}
{{/link-to}}
```

@taras I really like this, but I think the implementation is a little raw. Would love some feedback! I dont really know how to avoid those partials as well as make testing a bit easier....