### PR TITLE
Recalculate scrollbar when viewport dimensions change

### DIFF
--- a/addon/components/lt-scrollable.js
+++ b/addon/components/lt-scrollable.js
@@ -1,5 +1,31 @@
 import ScrollableComponent from 'ember-scrollable/components/scrollable';
 
 export default ScrollableComponent.extend({
-  classNames: ['lt-scrollable']
+  classNames: ['lt-scrollable'],
+
+  didInsertElement() {
+    this._super(...arguments);
+    this._updateViewportProps();
+  },
+
+  didUpdate() {
+    this._super(...arguments);
+    if(this._elementWidth !== this._getElementWidth() || this._elementHeight !== this._getElementHeight()) {
+      this._updateViewportProps();
+      this.send('recalculate');
+    }
+  },
+
+  _updateViewportProps() {
+    this._elementWidth = this._getElementWidth();
+    this._elementHeight = this._getElementHeight();
+  },
+
+  _getElementWidth() {
+    return this.$().css('width');
+  },
+
+  _getElementHeight() {
+    return this.$().css('height');
+  }
 });


### PR DESCRIPTION
When a dom element is removed or inserted, we dont recalculate the scrollable container. @taras this solution works but I believe can be improved. 