### PR TITLE
Determine virtualScrollbar via fixed header or footer

### DIFF
--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -3,8 +3,9 @@ import layout from 'ember-light-table/templates/components/light-table';
 import Table from 'ember-light-table/classes/Table';
 
 const {
-  computed,
-  assert
+  assert,
+  isEmpty,
+  computed
 } = Ember;
 
 /**
@@ -77,13 +78,19 @@ const LightTable =  Ember.Component.extend({
   height: null,
 
   /**
-   * Use ember-scrollable Trackpad Scroll Emulator for body
+   * Table component shared options
    *
-   * @property virtualScrollbar
-   * @type {Boolean}
-   * @default false
+   * @property sharedOptions
+   * @type {Object}
+   * @private
    */
-  virtualScrollbar: false,
+  sharedOptions: computed(function() {
+    return {
+      height: this.get('height'),
+      fixedHeader: false,
+      fixedFooter: false
+    };
+  }).readOnly(),
 
   style: computed('height', function() {
     let height = this.get('height');
@@ -94,9 +101,8 @@ const LightTable =  Ember.Component.extend({
 
   init() {
     this._super(...arguments);
-    assert(`[ember-light-table] table must be an instance of Table`, this.get('table') instanceof Table);
+    assert('[ember-light-table] table must be an instance of Table', this.get('table') instanceof Table);
   }
-
 });
 
 LightTable.reopenClass({

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -4,7 +4,6 @@ import Table from 'ember-light-table/classes/Table';
 
 const {
   assert,
-  isEmpty,
   computed
 } = Ember;
 

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -40,7 +40,7 @@ const {
 export default Ember.Component.extend({
   layout,
   classNames: ['lt-body-wrap'],
-  classNameBindings: ['canSelect', 'multiSelect', 'canExpand', 'virtualScrollbar'],
+  classNameBindings: ['canSelect', 'multiSelect', 'canExpand'],
 
   /**
    * @property table
@@ -150,28 +150,12 @@ export default Ember.Component.extend({
    */
   scrollBuffer: 500,
 
-  /**
-   * @property virtualScrollbar
-   * @type {Boolean}
-   */
-  virtualScrollbar: false,
-
   rows: computed.readOnly('table.visibleRows'),
   columns: computed.readOnly('table.visibleColumns'),
   colspan: computed.readOnly('columns.length'),
 
   _currSelectedIndex: -1,
   _prevSelectedIndex: -1,
-
-  didInsertElement() {
-    this._super(...arguments);
-    this._virtualScrollbarTimer = run.scheduleOnce('render', this, this._setVirtualScrollbar);
-  },
-
-  willDestroyElement() {
-    this._super(...arguments);
-    run.cancel(this._virtualScrollbarTimer);
-  },
 
   togglExpandedRow(row) {
     let multi = this.get('multiRowExpansion');
@@ -183,11 +167,6 @@ export default Ember.Component.extend({
       this.get('table.expandedRows').setEach('expanded', false);
       row.set('expanded', shouldExpand);
     }
-  },
-
-  _setVirtualScrollbar() {
-    const sharedOptions = this.get('sharedOptions');
-    this.set('virtualScrollbar', sharedOptions.fixedHeader || sharedOptions.fixedFooter);
   },
 
   actions: {

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -3,7 +3,6 @@ import layout from 'ember-light-table/templates/components/lt-body';
 import callAction from 'ember-light-table/utils/call-action';
 
 const {
-  run,
   computed
 } = Ember;
 

--- a/addon/components/lt-foot.js
+++ b/addon/components/lt-foot.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-foot';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
+const {
+  assert,
+  isEmpty
+} = Ember;
+
 /**
  * @module Components
  */
@@ -32,5 +37,17 @@ import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 export default Ember.Component.extend(TableHeaderMixin, {
   layout,
   classNames: ['lt-foot-wrap'],
-  table: null
+  table: null,
+  sharedOptions: null,
+
+  init() {
+    this._super(...arguments);
+
+    const sharedOptions = this.get('sharedOptions');
+    const fixed = this.get('fixed');
+
+    assert('[ember-light-table] The height property is required for fixed footer', !fixed || fixed && !isEmpty(sharedOptions.height));
+
+    sharedOptions.fixedFooter = fixed;
+  }
 });

--- a/addon/components/lt-foot.js
+++ b/addon/components/lt-foot.js
@@ -3,6 +3,7 @@ import layout from 'ember-light-table/templates/components/lt-foot';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
 const {
+  set,
   assert,
   isEmpty
 } = Ember;
@@ -43,11 +44,11 @@ export default Ember.Component.extend(TableHeaderMixin, {
   init() {
     this._super(...arguments);
 
-    const sharedOptions = this.get('sharedOptions');
+    const sharedOptions = this.get('sharedOptions') || {};
     const fixed = this.get('fixed');
 
     assert('[ember-light-table] The height property is required for fixed footer', !fixed || fixed && !isEmpty(sharedOptions.height));
 
-    sharedOptions.fixedFooter = fixed;
+    set(sharedOptions, 'fixedFooter', fixed);
   }
 });

--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -3,6 +3,7 @@ import layout from 'ember-light-table/templates/components/lt-head';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
 const {
+  set,
   assert,
   isEmpty
 } = Ember;
@@ -46,11 +47,11 @@ export default Ember.Component.extend(TableHeaderMixin, {
   init() {
     this._super(...arguments);
 
-    const sharedOptions = this.get('sharedOptions');
+    const sharedOptions = this.get('sharedOptions') || {};
     const fixed = this.get('fixed');
 
     assert('[ember-light-table] The height property is required for fixed header', !fixed || fixed && !isEmpty(sharedOptions.height));
 
-    sharedOptions.fixedHeader = fixed;
+    set(sharedOptions, 'fixedHeader', fixed);
   }
 });

--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-head';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
+const {
+  assert,
+  isEmpty
+} = Ember;
+
 /**
  * @module Components
  */
@@ -35,5 +40,17 @@ import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 export default Ember.Component.extend(TableHeaderMixin, {
   layout,
   classNames: ['lt-head-wrap'],
-  table: null
+  table: null,
+  sharedOptions: null,
+
+  init() {
+    this._super(...arguments);
+
+    const sharedOptions = this.get('sharedOptions');
+    const fixed = this.get('fixed');
+
+    assert('[ember-light-table] The height property is required for fixed header', !fixed || fixed && !isEmpty(sharedOptions.height));
+
+    sharedOptions.fixedHeader = fixed;
+  }
 });

--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -77,7 +77,7 @@ export default Ember.Mixin.create({
    */
   tableId: null,
 
-  renderInPlace: computed.readOnly('fixed'),
+  renderInPlace: computed.oneWay('fixed'),
   columnGroups: computed.readOnly('table.visibleColumnGroups'),
   subColumns: computed.readOnly('table.visibleSubColumns'),
   columns: computed.readOnly('table.visibleColumns'),

--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -22,7 +22,20 @@ export default Ember.Mixin.create({
    * @private
    */
   table: null,
-  
+
+  /**
+   * @property sharedOptions
+   * @type {Object}
+   * @private
+   */
+  sharedOptions: null,
+
+  /**
+   * @property tableActions
+   * @type {Object}
+   */
+  tableActions: null,
+
   /**
    * @property fixed
    * @type {Boolean}
@@ -64,14 +77,14 @@ export default Ember.Mixin.create({
    */
   tableId: null,
 
-  renderInPlace: computed.oneWay('fixed'),
-  columnGroups: computed.oneWay('table.visibleColumnGroups'),
-  subColumns: computed.oneWay('table.visibleSubColumns'),
-  columns: computed.oneWay('table.visibleColumns'),
+  renderInPlace: computed.readOnly('fixed'),
+  columnGroups: computed.readOnly('table.visibleColumnGroups'),
+  subColumns: computed.readOnly('table.visibleSubColumns'),
+  columns: computed.readOnly('table.visibleColumns'),
 
   sortIcons: computed('iconAscending', 'iconDescending', function() {
     return this.getProperties(['iconAscending', 'iconDescending']);
-  }),
+  }).readOnly(),
 
   actions: {
     /**

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -1,6 +1,6 @@
 .ember-light-table {
   height: inherit;
-  overflow: hidden;
+  overflow: auto;
   display: flex;
   flex-direction: column;
 }
@@ -22,7 +22,6 @@
 }
 
 .ember-light-table .lt-head-wrap,
-.ember-light-table .lt-body-wrap,
 .ember-light-table .lt-foot-wrap {
   overflow-y: auto;
   overflow-x: hidden;

--- a/addon/templates/components/light-table.hbs
+++ b/addon/templates/components/light-table.hbs
@@ -1,5 +1,5 @@
 {{yield (hash
-  head=(component 'lt-head' tableId=elementId table=table tableActions=tableActions)
-  body=(component 'lt-body' tableId=elementId table=table tableActions=tableActions virtualScrollbar=virtualScrollbar)
-  foot=(component 'lt-foot' tableId=elementId table=table tableActions=tableActions)
+  head=(component 'lt-head' tableId=elementId table=table tableActions=tableActions sharedOptions=sharedOptions)
+  body=(component 'lt-body' tableId=elementId table=table tableActions=tableActions sharedOptions=sharedOptions)
+  foot=(component 'lt-foot' tableId=elementId table=table tableActions=tableActions sharedOptions=sharedOptions)
 )}}

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -1,6 +1,6 @@
 {{#lt-scrollable
   tagName=''
-  virtualScrollbar=virtualScrollbar
+  virtualScrollbar=(or sharedOptions.fixedHeader sharedOptions.fixedFooter)
   autoHide=autoHideScrollbar
 }}
   <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -2,8 +2,6 @@
   tagName=''
   virtualScrollbar=virtualScrollbar
   autoHide=autoHideScrollbar
-  onScrolledToBottom=(action "onScrolledToBottom")
-  scrollBuffer=scrollBuffer
 }}
   <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>
 
@@ -35,6 +33,10 @@
       {{/if}}
     </tbody>
   </table>
+
+  {{#if onScrolledToBottom}}
+    {{lt-infinity onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
+  {{/if}}
 
   <div id={{concat tableId '_inline_foot'}} class="lt-inline lt-foot"></div>
 {{/lt-scrollable}}

--- a/addon/templates/components/lt-scrollable.hbs
+++ b/addon/templates/components/lt-scrollable.hbs
@@ -5,9 +5,7 @@
     as |scrollbar|
   }}
     {{yield}}
-    {{lt-infinity onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
   {{/ember-scrollable}}
 {{else}}
   {{yield}}
-  {{lt-infinity onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
 {{/if}}

--- a/tests/dummy/app/templates/expandable.hbs
+++ b/tests/dummy/app/templates/expandable.hbs
@@ -25,11 +25,12 @@
 
     <div class="panel-body table-container">
 {{!-- BEGIN-SNIPPET expandable-table --}}
-{{#light-table table height='65vh' virtualScrollbar=true as |t|}}
+{{#light-table table height='65vh' as |t|}}
   {{t.head
     onColumnClick=(action 'onColumnClick')
     iconAscending='fa fa-sort-asc'
     iconDescending='fa fa-sort-desc'
+    fixed=true
   }}
 
   {{#t.body

--- a/tests/dummy/app/templates/grouped.hbs
+++ b/tests/dummy/app/templates/grouped.hbs
@@ -25,7 +25,7 @@
 
     <div class="panel-body table-container fixed-header">
 {{!-- BEGIN-SNIPPET grouped-table --}}
-{{#light-table table height='65vh' virtualScrollbar=true as |t|}}
+{{#light-table table height='65vh' as |t|}}
   {{t.head
     onColumnClick=(action 'onColumnClick')
     iconAscending='fa fa-sort-asc'

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -23,7 +23,7 @@
     </div>
     <div class="panel-body table-container fixed-header">
 {{!-- BEGIN-SNIPPET simple-table --}}
-{{#light-table table height='65vh' virtualScrollbar=true as |t|}}
+{{#light-table table height='65vh' as |t|}}
 
   {{t.head
     onColumnClick=(action 'onColumnClick')

--- a/tests/dummy/app/templates/selectable.hbs
+++ b/tests/dummy/app/templates/selectable.hbs
@@ -35,11 +35,12 @@
 
     <div class="panel-body table-container">
 {{!-- BEGIN-SNIPPET selectable-table --}}
-{{#light-table table height='65vh' virtualScrollbar=true as |t|}}
+{{#light-table table height='65vh' as |t|}}
   {{t.head
     onColumnClick=(action 'onColumnClick')
     iconAscending='fa fa-sort-asc'
     iconDescending='fa fa-sort-desc'
+    fixed=true
   }}
 
   {{#t.body

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -55,7 +55,7 @@ test('fixed header', function(assert) {
   this.set('fixed', true);
 
   this.render(hbs`
-    {{#light-table table id='lightTable' as |t|}}
+    {{#light-table table height='500px' id='lightTable' as |t|}}
       {{t.head fixed=fixed}}
       {{t.body}}
     {{/light-table}}
@@ -74,7 +74,7 @@ test('fixed footer', function(assert) {
   this.set('fixed', true);
 
   this.render(hbs`
-    {{#light-table table id='lightTable' as |t|}}
+    {{#light-table table height='500px' id='lightTable' as |t|}}
       {{t.body}}
       {{t.foot fixed=fixed}}
     {{/light-table}}


### PR DESCRIPTION
Instead of having to explicitly set `virtualScrollbar: true`, we should just do it automatically if a fixed header or footer is defined. To do this while still keeping `fixed: true` on the `{{t.head}}` and `{{t.foot}}` contextual components, I have to pass some shared object around and do some logic via `run.scheduleOnce` in lt-body.js. 