### PR TITLE
Make text unselectable if column is sortable

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -61,6 +61,7 @@
 
 .ember-light-table .lt-column.is-sortable {
   cursor: pointer;
+  user-select: none;
 }
 
 .ember-light-table .lt-row.is-expandable,


### PR DESCRIPTION
I find myself accidentally highlighting the table headers when clicking to sort:

![](https://i.imgur.com/JjAmG0b.png)