### PR TITLE
[WIP] Fixed columns

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -26,6 +26,13 @@ export default class Column extends Ember.Object.extend({
   hidden: false,
 
   /**
+   * @property fixed
+   * @type {Boolean}
+   * @default false
+   */
+  fixed: false,
+
+  /**
    * @property ascending
    * @type {Boolean}
    * @default true

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -117,7 +117,27 @@ export default class Table extends Ember.Object.extend({
       }
       return arr;
     }, []));
-  }).readOnly()
+  }).readOnly(),
+
+  fixedColumns: computed.filterBy('visibleColumns', 'fixed', true),
+  standardColumns: computed.filterBy('visibleColumns', 'fixed', false),
+
+  fixedColumnWidth: computed('fixedColumns.[]', function() {
+    let fixedColumns = this.get('fixedColumns');
+
+    return fixedColumns.reduce((prev, column) => {
+      if (typeof column.width === 'undefined') {
+        return 0;
+      }
+
+      // column definitions use strings with px, so strip it out
+      let width = parseInt(column.width.replace(/px/, ''));
+
+      return prev + width;
+    }, 0);
+  }),
+
+  //
 }) {
   /**
    * @class Table

--- a/addon/components/columns/base.js
+++ b/addon/components/columns/base.js
@@ -16,7 +16,7 @@ const Column = Component.extend({
   tagName: 'th',
   classNames: ['lt-column'],
   attributeBindings: ['width', 'colspan', 'rowspan'],
-  classNameBindings: ['align', 'isGroupColumn:lt-group-column', 'isHideable', 'isSortable', 'isSorted', 'isResizable', 'column.classNames'],
+  classNameBindings: ['align', 'isGroupColumn:lt-group-column', 'isHideable', 'isSortable', 'isSorted', 'isResizable', 'isFixed', 'column.classNames'],
 
   width: computed.readOnly('column.width'),
   isGroupColumn: computed.readOnly('column.isGroupColumn'),
@@ -24,6 +24,7 @@ const Column = Component.extend({
   isSorted: computed.readOnly('column.sorted'),
   isHideable: computed.readOnly('column.hideable'),
   isResizable: computed.readOnly('column.resizable'),
+  isFixed: computed.readOnly('column.fixed'),
 
   align: computed('column.align', function () {
     return `align-${this.get('column.align')}`;

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -4,7 +4,8 @@ import callAction from 'ember-light-table/utils/call-action';
 
 const {
   Component,
-  computed
+  computed,
+  run: { debounce }
 } = Ember;
 
 /**
@@ -151,8 +152,25 @@ export default Component.extend({
   scrollBuffer: 500,
 
   rows: computed.readOnly('table.visibleRows'),
-  columns: computed.readOnly('table.visibleColumns'),
-  colspan: computed.readOnly('columns.length'),
+  fixedColumns: computed.readOnly('table.fixedColumns'),
+  standardColumns: computed.readOnly('table.standardColumns'),
+
+  shouldUseVirtualScrollbar: computed('sharedOptions.{fixedHeader,fixedFooter}', 'fixedColumns.length', function() {
+    let { fixedHeader, fixedFooter } = this.get('sharedOptions');
+    let numberOfFixedColumns = this.get('fixedColumns.length');
+
+    return numberOfFixedColumns === 0 && fixedHeader || fixedFooter;
+  }),
+
+  didInsertElement() {
+    let shouldUseVirtualScrollbar = this.get('shouldUseVirtualScrollbar');
+
+    if (!shouldUseVirtualScrollbar) {
+      let height = this.$().height();
+
+      this.$('.lt-column-wrapper').height(height);
+    }
+  },
 
   _currSelectedIndex: -1,
   _prevSelectedIndex: -1,

--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -45,6 +45,22 @@ export default Component.extend(TableHeaderMixin, {
   table: null,
   sharedOptions: null,
 
+  didInsertElement() {
+    this._setHeaderHeight();
+  },
+
+  // TODO: both fixed and not
+  _setHeaderHeight() {
+    let [div] = this.$('.lt-column-wrapper.standard-columns .lt-head');
+    let [clientRects] = div.getClientRects();
+    let {height} = clientRects;
+
+    this.$().css({
+      height,
+      'flex-basis': height
+    });
+  },
+
   init() {
     this._super(...arguments);
 

--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -81,6 +81,8 @@ export default Ember.Mixin.create({
   columnGroups: computed.readOnly('table.visibleColumnGroups'),
   subColumns: computed.readOnly('table.visibleSubColumns'),
   columns: computed.readOnly('table.visibleColumns'),
+  fixedColumns: computed.readOnly('table.fixedColumns'),
+  standardColumns: computed.readOnly('table.standardColumns'),
 
   sortIcons: computed('iconAscending', 'iconDescending', function() {
     return this.getProperties(['iconAscending', 'iconDescending']);

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -38,6 +38,24 @@
   flex: 1 0 auto;
 }
 
+.ember-light-table .lt-column-wrapper {
+  position: absolute;
+}
+
+.ember-light-table .lt-column-wrapper.fixed-columns {
+  overflow: hidden;
+  z-index: 2;
+}
+
+.ember-light-table .lt-column-wrapper.standard-columns {
+  overflow-x: auto;
+  z-index: 1;
+}
+
+.ember-light-table .lt-head-wrap .standard-columns {
+  overflow: hidden;
+}
+
 .ember-light-table .lt-column {
   position: relative;
 }

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -1,38 +1,73 @@
 {{#lt-scrollable
   tagName=''
-  virtualScrollbar=(or sharedOptions.fixedHeader sharedOptions.fixedFooter)
-  autoHide=autoHideScrollbar
+  virtualScrollbar=shouldUseVirtualScrollbar
+  autoHide=false
 }}
   <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>
 
-  <table>
-    <tbody class="lt-body">
-      {{#if overwrite}}
-        {{yield columns rows}}
-      {{else}}
-        {{#each rows as |row|}}
-          {{lt-row row columns
-            tableActions=tableActions
-            canExpand=canExpand
-            canSelect=canSelect
-            click=(action 'onRowClick' row)
-            doubleClick=(action 'onRowDoubleClick' row)}}
+  {{#if (gt fixedColumns.length 0)}}
+    <div class="lt-column-wrapper fixed-columns" style={{ltColumnWrapperStyle.fixed}}>
+      <table>
+        <tbody class="lt-body">
+          {{#if overwrite}}
+            {{yield fixedColumns rows}}
+          {{else}}
+            {{#each rows as |row|}}
+              {{lt-row row fixedColumns
+                tableActions=tableActions
+                canExpand=canExpand
+                canSelect=canSelect
+                click=(action 'onRowClick' row)
+                doubleClick=(action 'onRowDoubleClick' row)}}
+
+              {{yield (hash
+                expanded-row=(component 'lt-spanned-row' classes='lt-expanded-row' colspan=fixedColumns.length yield=row visible=row.expanded)
+                loader=(component 'lt-spanned-row' visible=false)
+                no-data=(component 'lt-spanned-row' visible=false)
+              ) rows}}
+            {{/each}}
+
+            {{yield (hash
+              loader=(component 'lt-spanned-row' classes='lt-is-loading' colspan=fixedColumns.length)
+              no-data=(component 'lt-spanned-row' classes='lt-no-data' colspan=fixedColumns.length)
+              expanded-row=(component 'lt-spanned-row' visible=false)
+            ) rows}}
+          {{/if}}
+        </tbody>
+      </table>
+    </div>
+  {{/if}}
+
+  <div class="lt-column-wrapper standard-columns" style={{ltColumnWrapperStyle.standard}}>
+    <table>
+      <tbody class="lt-body">
+        {{#if overwrite}}
+          {{yield standardColumns rows}}
+        {{else}}
+          {{#each rows as |row|}}
+            {{lt-row row standardColumns
+              tableActions=tableActions
+              canExpand=canExpand
+              canSelect=canSelect
+              click=(action 'onRowClick' row)
+              doubleClick=(action 'onRowDoubleClick' row)}}
+
+            {{yield (hash
+              expanded-row=(component 'lt-spanned-row' classes='lt-expanded-row' colspan=standardColumns.length yield=row visible=row.expanded)
+              loader=(component 'lt-spanned-row' visible=false)
+              no-data=(component 'lt-spanned-row' visible=false)
+            ) rows}}
+          {{/each}}
 
           {{yield (hash
-            expanded-row=(component 'lt-spanned-row' classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
-            loader=(component 'lt-spanned-row' visible=false)
-            no-data=(component 'lt-spanned-row' visible=false)
+            loader=(component 'lt-spanned-row' classes='lt-is-loading' colspan=standardColumns.length)
+            no-data=(component 'lt-spanned-row' classes='lt-no-data' colspan=standardColumns.length)
+            expanded-row=(component 'lt-spanned-row' visible=false)
           ) rows}}
-        {{/each}}
-
-        {{yield (hash
-          loader=(component 'lt-spanned-row' classes='lt-is-loading' colspan=colspan)
-          no-data=(component 'lt-spanned-row' classes='lt-no-data' colspan=colspan)
-          expanded-row=(component 'lt-spanned-row' visible=false)
-        ) rows}}
-      {{/if}}
-    </tbody>
-  </table>
+        {{/if}}
+      </tbody>
+    </table>
+  </div>
 
   {{#if onScrolledToBottom}}
     {{lt-infinity onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}

--- a/addon/templates/components/lt-head.hbs
+++ b/addon/templates/components/lt-head.hbs
@@ -1,35 +1,36 @@
 {{#ember-wormhole to=(concat tableId '_inline_head') renderInPlace=renderInPlace}}
-  <table>
-    <thead class="lt-head">
-      {{#if hasBlock}}
-        {{yield columnGroups subColumns}}
-      {{else}}
+  <div class="fixed-columns lt-column-wrapper">
+    <table>
+      <thead class="lt-head">
+        {{#if hasBlock}}
+          {{yield columnGroups subColumns}}
+        {{else}}
 
         {{!- There is an issue where if there are more than 1 row and the first has a colspan,
-           the td's fail to hold their width. Creating a scaffolding will setup the table columns correctly
+        the td's fail to hold their width. Creating a scaffolding will setup the table columns correctly
         --}}
         {{#if subColumns.length}}
           <tr>
             {{#each subColumns as |column|}}
-              <td width={{column.width}} class="lt-scaffolding"></td>
+            <td width={{column.width}} class="lt-scaffolding"></td>
             {{/each}}
           </tr>
         {{/if}}
 
-        <tr>
-          {{#each columnGroups as |column|}}
-            {{component (concat 'light-table/columns/' column.type) column
+          <tr>
+            {{#each fixedColumns as |column|}}
+              {{component (concat 'light-table/columns/' column.type) column
               table=table
               tableActions=tableActions
               sortIcons=sortIcons
               click=(action 'onColumnClick' column)
               doubleClick=(action 'onColumnDoubleClick' column)
               columnResized=(action 'onColumnResized')}}
-          {{/each}}
-        </tr>
-        <tr>
-          {{#each subColumns as |column|}}
-            {{component (concat 'light-table/columns/' column.type) column
+            {{/each}}
+          </tr>
+          <tr>
+            {{#each subColumns as |column|}}
+              {{component (concat 'light-table/columns/' column.type) column
               table=table
               rowspan=1
               classNames="lt-sub-column"
@@ -38,9 +39,58 @@
               click=(action 'onColumnClick' column)
               doubleClick=(action 'onColumnDoubleClick' column)
               columnResized=(action 'onColumnResized')}}
-          {{/each}}
-        </tr>
-      {{/if}}
-    </thead>
-  </table>
+            {{/each}}
+          </tr>
+
+        {{/if}}
+      </thead>
+    </table>
+  </div>
+
+  <div class="standard-columns lt-column-wrapper">
+    <table>
+      <thead class="lt-head">
+        {{#if hasBlock}}
+          {{yield columnGroups subColumns}}
+        {{else}}
+
+        {{!- There is an issue where if there are more than 1 row and the first has a colspan,
+        the td's fail to hold their width. Creating a scaffolding will setup the table columns correctly
+        --}}
+        {{#if subColumns.length}}
+          <tr>
+            {{#each subColumns as |column|}}
+            <td width={{column.width}} class="lt-scaffolding"></td>
+            {{/each}}
+          </tr>
+        {{/if}}
+
+          <tr>
+            {{#each standardColumns as |column|}}
+              {{component (concat 'light-table/columns/' column.type) column
+              table=table
+              tableActions=tableActions
+              sortIcons=sortIcons
+              click=(action 'onColumnClick' column)
+              doubleClick=(action 'onColumnDoubleClick' column)
+              columnResized=(action 'onColumnResized')}}
+            {{/each}}
+          </tr>
+          <tr>
+            {{#each subColumns as |column|}}
+              {{component (concat 'light-table/columns/' column.type) column
+              table=table
+              rowspan=1
+              classNames="lt-sub-column"
+              tableActions=tableActions
+              sortIcons=sortIcons
+              click=(action 'onColumnClick' column)
+              doubleClick=(action 'onColumnDoubleClick' column)
+              columnResized=(action 'onColumnResized')}}
+            {{/each}}
+          </tr>
+        {{/if}}
+      </thead>
+    </table>
+  </div>
 {{/ember-wormhole}}

--- a/tests/dummy/app/controllers/fixed-columns.js
+++ b/tests/dummy/app/controllers/fixed-columns.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+import TableController from './table';
+
+const {
+  computed
+} = Ember;
+
+export default TableController.extend({
+  columns: computed(function() {
+    return [{
+      label: 'Avatar',
+      valuePath: 'avatar',
+      width: '60px',
+      sortable: false,
+      fixed: true,
+      cellComponent: 'user-avatar'
+    }, {
+      label: 'First Name',
+      valuePath: 'firstName',
+      width: '150px',
+      fixed: true,
+      format(value) {
+        return value.toUpperCase();
+      }
+    }, {
+      label: 'Last Name',
+      valuePath: 'lastName',
+      width: '150px'
+    }, {
+      label: 'Address',
+      valuePath: 'address',
+      width: '500px'
+    }, {
+      label: 'State',
+      valuePath: 'state',
+      width: '200px'
+    }, {
+      label: 'Country',
+      valuePath: 'country',
+      width: '200px'
+    }];
+  })
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('expandable');
   this.route('selectable');
   this.route('resizable');
+  this.route('fixed-columns');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/fixed-columns.js
+++ b/tests/dummy/app/routes/fixed-columns.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    return this.store.query('user', {page: 1, limit: 20});
+  },
+
+  setupController(controller, model) {
+    controller.get('table').setRows(model.toArray());
+  },
+});

--- a/tests/dummy/app/styles/table.less
+++ b/tests/dummy/app/styles/table.less
@@ -71,4 +71,12 @@
       padding: 0 10px;
     }
   }
+
+  .fixed-columns {
+    border-right: 2px solid rgba(221, 106, 88, 0.30);
+
+    th, td {
+      background: rgba(221, 106, 88, 0.10);
+    }
+  }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -30,6 +30,9 @@
         {{#link-to 'selectable' tagName="li"}}
           {{link-to 'Selectable Rows' 'selectable'}}
         {{/link-to}}
+        {{#link-to 'fixed-columns' tagName="li"}}
+          {{link-to 'Fixed Columns' 'fixed-columns'}}
+        {{/link-to}}
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li><a href="docs">Documentation</a></li>

--- a/tests/dummy/app/templates/fixed-columns.hbs
+++ b/tests/dummy/app/templates/fixed-columns.hbs
@@ -1,0 +1,59 @@
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="table-1">
+      <a role="button" data-toggle="collapse" data-parent="#accordion" href="#code-snippet" aria-expanded="true" aria-controls="code-snippet">
+        <h4 class="panel-title">Fixed Columns <span class="code-icon fa fa-code pull-right"></span></h4>
+      </a>
+    </div>
+
+    <div id="code-snippet" class="panel-collapse collapse" role="tabpanel" aria-labelledby="table-1">
+      <div class="panel-body code-snippet">
+       <ul class="nav nav-tabs" role="tablist">
+           <li role="presentation" class="active"><a href="#component" aria-controls="component" role="tab" data-toggle="tab">component.js</a></li>
+           <li role="presentation"><a href="#template" aria-controls="template" role="tab" data-toggle="tab">template.hbs</a></li>
+           <li role="presentation"><a href="#user-avatar" aria-controls="user-avatar" role="tab" data-toggle="tab">user-avatar.hbs</a></li>
+           <li role="presentation"><a href="#no-data" aria-controls="no-data" role="tab" data-toggle="tab">no-data.hbs</a></li>
+           <li role="presentation"><a href="#table-loader" aria-controls="table-loader" role="tab" data-toggle="tab">table-loader.hbs</a></li>
+         </ul>
+         <div class="tab-content">
+           <div role="tabpanel" class="tab-pane fade in active" id="component">{{code-snippet name="selectable-table.js"}}</div>
+           <div role="tabpanel" class="tab-pane fade" id="template">{{code-snippet name="selectable-table.hbs"}}</div>
+           <div role="tabpanel" class="tab-pane fade" id="user-avatar">{{code-snippet name="user-avatar.hbs"}}</div>
+           <div role="tabpanel" class="tab-pane fade" id="no-data">{{code-snippet name="no-data.hbs"}}</div>
+           <div role="tabpanel" class="tab-pane fade" id="table-loader">{{code-snippet name="table-loader.hbs"}}</div>
+         </div>
+       </div>
+    </div>
+
+    <div class="panel-body table-container">
+      {{!-- BEGIN-SNIPPET selectable-table --}}
+      {{#light-table table height='65vh' as |t|}}
+        {{t.head
+          onColumnClick=(action 'onColumnClick')
+          iconAscending='fa fa-sort-asc'
+          iconDescending='fa fa-sort-desc'
+          fixed=true
+        }}
+
+        {{#t.body
+          multiSelect=true
+          onScrolledToBottom=(action 'onScrolledToBottom')
+          as |body|
+        }}
+          {{#if isLoading}}
+            {{#body.loader}}
+              {{table-loader}}
+            {{/body.loader}}
+          {{/if}}
+
+          {{#if (and (not isLoading) table.isEmpty)}}
+            {{#body.no-data}}
+              {{no-data}}
+            {{/body.no-data}}
+          {{/if}}
+        {{/t.body}}
+      {{/light-table}}
+      {{!-- END-SNIPPET --}}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This has a decent amount more for me to do before I'd consider it mergeable but I wanted to open it up for discussion.

This library is gaining traction, so I wanted to look at adding some of the high level features developed in https://github.com/cball/justa-table so that I can put resources towards this library instead. We currently have 3 projects that need fixed column support and I know others that have expressed the need for that feature as well. @taras had concerns using fixed columns in https://github.com/offirgolan/ember-light-table/issues/114. While complicated to implement, it is a pretty common ask for complex tables and I don't think you can always just implement a different UI.

First, the *largest issue*: Trackpad Scroll Emulator which is used by `ember-scrollable` can only scroll 1 way. (see https://github.com/jnicol/trackpad-scroll-emulator#5-limitations). As such, in this PR when there are fixed columns present, native scrollbars are used instead. I'd actually argue to put the work in to make native scrollbars work across the board but that's a separate issue.

TODOs before I think this is ready:
- [ ] fix and support columnGroups
- [ ] fix ember-infinity
- [ ] add missing tests for new functionality
- [ ] reduce duplication (currently a decent amount of copy/paste) to set up the columns
- [ ] figure out a better way to organize the fixed column specific code

![screen recording 2016-07-29 at 09 10 pm](https://cloud.githubusercontent.com/assets/14339/17267166/eb2af2a2-55d0-11e6-88ea-74118c007bf3.gif)

