### PR TITLE
[BUGFIX] onScrolledToBottom doesnt get re-triggered after removing table rows

### DIFF
--- a/addon/components/lt-infinity.js
+++ b/addon/components/lt-infinity.js
@@ -31,7 +31,7 @@ export default Component.extend(InViewportMixin, {
   },
 
   didEnterViewport() {
-    this._throttleScrolledToBottom();
+    this._debounceScrolledToBottom();
   },
 
   didExitViewport() {
@@ -48,19 +48,19 @@ export default Component.extend(InViewportMixin, {
   }),
 
   _scheduleScrolledToBottom() {
-    this._schedulerTimer = run.scheduleOnce('afterRender', this, this._throttleScrolledToBottom);
+    this._schedulerTimer = run.scheduleOnce('afterRender', this, this._debounceScrolledToBottom);
   },
 
-  _throttleScrolledToBottom(spacing = 100) {
+  _debounceScrolledToBottom(delay = 100) {
     /*
-      This throttle is needed when there is not enough spancing between onScrolledToBottom calls.
-      Without this throttle, all rows will be rendered causing immense performance problems
+      This debounce is needed when there is not enough delay between onScrolledToBottom calls.
+      Without this debounce, all rows will be rendered causing immense performance problems
      */
-    this._throttleTimer = run.throttle(this, this.sendAction, 'onScrolledToBottom', spacing);
+    this._debounceTimer = run.debounce(this, this.sendAction, 'onScrolledToBottom', delay);
   },
 
   _cancelTimers() {
     run.cancel(this._schedulerTimer);
-    run.cancel(this._throttleTimer);
+    run.cancel(this._debounceTimer);
   }
 });

--- a/addon/components/lt-infinity.js
+++ b/addon/components/lt-infinity.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/lt-infinity';
 import InViewportMixin from 'ember-in-viewport';
 
-const { Component, run } = Ember;
+const { Component, observer, run } = Ember;
 
 export default Component.extend(InViewportMixin, {
   classNames: ['lt-infinity'],
@@ -11,18 +11,6 @@ export default Component.extend(InViewportMixin, {
 
   rows: null,
   scrollBuffer: null,
-
-  init() {
-    this._super(...arguments);
-
-    /*
-      When the table doesnt have enough rows to push this component
-      out of the viewport, it will only call didEnterViewport once.
-      This sets up an observer that will add more rows and then be destroyed
-      once this component comes out of view.
-     */
-    this.addObserver('rows.[]', this, this._scheduleDidEnterViewport);
-  },
 
   didInsertElement() {
     this._super(...arguments);
@@ -43,30 +31,36 @@ export default Component.extend(InViewportMixin, {
   },
 
   didEnterViewport() {
-    this.sendAction('onScrolledToBottom');
+    this._throttleScrolledToBottom();
   },
 
   didExitViewport() {
-    if(this.hasObserverFor('rows.[]')) {
-      this._cancelTimers();
-      this.removeObserver('rows.[]', this, this._scheduleDidEnterViewport);
+    this._cancelTimers();
+  },
+
+  scheduleScrolledToBottom: observer('rows.[]', 'viewportEntered', function() {
+    if(this.get('viewportEntered')) {
+      /*
+        Continue scheduling onScrolledToBottom until no longer in viewport
+       */
+      this._scheduleScrolledToBottom();
     }
+  }),
+
+  _scheduleScrolledToBottom() {
+    this._schedulerTimer = run.scheduleOnce('afterRender', this, this._throttleScrolledToBottom);
   },
 
-  _scheduleDidEnterViewport() {
-    this._schedulerTimer = run.scheduleOnce('afterRender', this, this._debounceDidEnterViewport);
-  },
-
-  _debounceDidEnterViewport() {
+  _throttleScrolledToBottom(spacing = 100) {
     /*
-      This debounce is needed when there is not enough delay when calling onScrolledToBottom.
-      Without this debounce, all rows will be rendered causing immense performance problems
+      This throttle is needed when there is not enough spancing between onScrolledToBottom calls.
+      Without this throttle, all rows will be rendered causing immense performance problems
      */
-    this._debounceTimer = run.debounce(this, this.didEnterViewport, 100);
+    this._throttleTimer = run.throttle(this, this.sendAction, 'onScrolledToBottom', spacing);
   },
 
   _cancelTimers() {
     run.cancel(this._schedulerTimer);
-    run.cancel(this._debounceTimer);
+    run.cancel(this._throttleTimer);
   }
 });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.1",
-    "yuidoc-ember-theme": "^1.1.4"
+    "yuidoc-ember-theme": "^1.2.1"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/controllers/table.js
+++ b/tests/dummy/app/controllers/table.js
@@ -10,7 +10,7 @@ export default Ember.Controller.extend({
   table: null,
   sort: null,
   page: 1,
-  limit: 20,
+  limit: 10,
   dir: 'asc',
   isLoading: false,
   canLoadMore: true,

--- a/tests/dummy/app/routes/table-route.js
+++ b/tests/dummy/app/routes/table-route.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model() {
-    return this.store.query('user', {page: 1, limit: 20});
+    return this.store.query('user', {page: 1, limit: 10});
   },
 
   setupController(controller, model) {


### PR DESCRIPTION
This is related to #108. When you sort and clear all the table rows from the table onScrolledToBottom gets triggered only once since the observer to get more data until out of viewport has been destroyed. 