### PR TITLE
[Experimental] Add unfortunate hacks to get ember-sortable working :(

### DIFF
--- a/addon/components/columns/base.js
+++ b/addon/components/columns/base.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/columns/base';
+import SortableItem from 'ember-sortable/mixins/sortable-item';
 
 const {
   Component,
@@ -11,7 +12,7 @@ const {
  * @module Column Types
  * @class Base Column
  */
-const Column = Component.extend({
+const Column = Component.extend(SortableItem, {
   layout,
   tagName: 'th',
   classNames: ['lt-column'],
@@ -25,6 +26,9 @@ const Column = Component.extend({
   isHideable: computed.readOnly('column.hideable'),
   isResizable: computed.readOnly('column.resizable'),
   isDraggable: computed.readOnly('column.draggable'),
+
+  group: computed.readOnly('draggableGroup'),
+  model: computed.readOnly('column'),
 
   align: computed('column.align', function () {
     return `align-${this.get('column.align')}`;

--- a/addon/components/lt-sortable-group.js
+++ b/addon/components/lt-sortable-group.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+import SortableGroup from 'ember-sortable/components/sortable-group';
+import layout from 'ember-sortable/templates/components/sortable-group';
+const { get, set, typeOf } = Ember;
+
+export default SortableGroup.extend({
+  layout,
+
+  update() {
+    let sortedItems = this.get('sortedItems');
+    // Position of the first element
+    let position = this._itemPosition;
+
+    // Just in case we haven’t called prepare first.
+    if (position === undefined) {
+      position = this.get('itemPosition');
+    }
+
+    sortedItems.forEach(item => {
+      let dimension;
+      let direction = this.get('direction');
+
+      if (!get(item, 'isDragging')) {
+        set(item, direction, position);
+      }
+
+      // add additional spacing around active element
+      if (get(item, 'isBusy')) {
+        position += get(item, 'spacing') * 2;
+      }
+
+      if (direction === 'x') {
+        dimension = 'width';
+      }
+      if (direction === 'y') {
+        dimension = 'height';
+      }
+
+      position += toNumber(get(item, dimension));
+    });
+  },
+});
+
+function toNumber(x) {
+  switch (typeOf(x)) {
+    case 'number':
+      return x;
+    case 'string':
+      return Number(x.match(/\d+/)[0]);
+    default:
+      return Number(x);
+  }
+}

--- a/addon/templates/components/columns/base.hbs
+++ b/addon/templates/components/columns/base.hbs
@@ -1,14 +1,12 @@
-{{#lt-draggable column=column group=draggableGroup}}
-  {{#if column.component}}
-    {{component column.component column=column table=table tableActions=tableActions sortIcons=sortIcons}}
-  {{else}}
-    {{column.label}}
-    {{#if column.sorted}}
-      <span class="lt-sort-icon {{if column.ascending sortIcons.iconAscending sortIcons.iconDescending}}"></span>
-    {{/if}}
+{{#if column.component}}
+  {{component column.component column=column table=table tableActions=tableActions sortIcons=sortIcons}}
+{{else}}
+  {{column.label}}
+  {{#if column.sorted}}
+    <span class="lt-sort-icon {{if column.ascending sortIcons.iconAscending sortIcons.iconDescending}}"></span>
   {{/if}}
+{{/if}}
 
-  {{#if isResizable}}
-    {{lt-column-resize column=column columnResized=(action 'columnResized')}}
-  {{/if}}
-{{/lt-draggable}}
+{{#if isResizable}}
+  {{lt-column-resize column=column columnResized=(action 'columnResized')}}
+{{/if}}

--- a/addon/templates/components/lt-head.hbs
+++ b/addon/templates/components/lt-head.hbs
@@ -17,7 +17,7 @@
         {{/if}}
 
         <tr>
-          {{#sortable-group direction="x" tagName="" onChange="reorderColumns" as |group|}}
+          {{#lt-sortable-group direction="x" tagName="" onChange="reorderColumns" as |group|}}
             {{#each columnGroups as |column|}}
               {{component (concat 'light-table/columns/' column.type) column
                 table=table
@@ -28,12 +28,12 @@
                 doubleClick=(action 'onColumnDoubleClick' column)
                 columnResized=(action 'onColumnResized')}}
             {{/each}}
-         {{/sortable-group}}
+         {{/lt-sortable-group}}
         </tr>
 
         <tr>
           {{#each columnGroups as |colGroup|}}
-            {{#sortable-group direction="x" tagName="" onChange="reorderSubColumns" as |group|}}
+            {{#lt-sortable-group direction="x" tagName="" onChange="reorderSubColumns" as |group|}}
               {{#each colGroup.visibleSubColumns as |column|}}
                 {{component (concat 'light-table/columns/' column.type) column
                   table=table
@@ -46,7 +46,7 @@
                   doubleClick=(action 'onColumnDoubleClick' column)
                   columnResized=(action 'onColumnResized')}}
               {{/each}}
-            {{/sortable-group}}
+            {{/lt-sortable-group}}
           {{/each}}
         </tr>
       {{/if}}

--- a/app/components/lt-sortable-group.js
+++ b/app/components/lt-sortable-group.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-light-table/components/lt-sortable-group';


### PR DESCRIPTION
Ember-sortable is sadly not smart enough to deal with the idea of sorting elements that are not immediately adjacent. The change I had to make to get things working is to mixin sortable-item to columns/base. Not ideal, and a good example of why mixins are usually not the answer :/

Further, because columns/base has its own notion of `width`—which could be a string—I’ve had to clumsily subclass sortable-group to anticipate and parse such values.

All in all, ember-sortable has not proved a particularly elegants solution for this case. Honestly, I’m not surprised… it was written to deal with a very simple case and inevitably users of the addon have come up with much more ambitious solutions.

There is a rewrite underway on the jj-abrams branch of ember-sortable and I’ll definitely take this use case into consideration when designing the new APIs.

For now, I think you may be better served by another solution.