### PR TITLE
[FEATURE] Rename flattenedColumns to allColumns

### DIFF
--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -73,19 +73,19 @@ export default class Table extends Ember.Object.extend({
    * @property hideableColumns
    * @type {Ember.Array}
    */
-  hideableColumns: computed.filterBy('flattenedColumns', 'hideable', true).readOnly(),
+  hideableColumns: computed.filterBy('allColumns', 'hideable', true).readOnly(),
 
   /**
    * @property hiddenColumns
    * @type {Ember.Array}
    */
-  hiddenColumns: computed.filterBy('flattenedColumns', 'hidden', true).readOnly(),
+  hiddenColumns: computed.filterBy('allColumns', 'hidden', true).readOnly(),
 
   /**
    * @property visibleColumns
    * @type {Ember.Array}
    */
-  visibleColumns: computed.filterBy('flattenedColumns', 'hidden', false).readOnly(),
+  visibleColumns: computed.filterBy('allColumns', 'hidden', false).readOnly(),
 
   /**
    * @property visibleColumnGroups
@@ -109,10 +109,10 @@ export default class Table extends Ember.Object.extend({
   }).readOnly(),
 
   /**
-   * @property flattenedColumns
+   * @property allColumns
    * @type {Ember.Array}
    */
-  flattenedColumns: computed('columns.[]', 'columns.@each.subColumns', function() {
+  allColumns: computed('columns.[]', 'columns.@each.subColumns', function() {
     return emberArray(this.get('columns').reduce((arr, c) => {
       let subColumns = c.get('subColumns');
       if (isEmpty(subColumns)) {

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -55,7 +55,7 @@ test('CP - visibleSubColumns', function(assert) {
   assert.equal(table.get('visibleSubColumns.length'), 2);
 });
 
-test('CP - flattenedColumns', function(assert) {
+test('CP - allColumns', function(assert) {
   let table = new Table();
   let col = new Column();
   let group = new Column({
@@ -66,7 +66,7 @@ test('CP - flattenedColumns', function(assert) {
   });
 
   table.setColumns([col, group, group2]);
-  assert.equal(table.get('flattenedColumns.length'), 5);
+  assert.equal(table.get('allColumns.length'), 5);
 });
 
 


### PR DESCRIPTION
`flattenedColumns` was meant to be used only as private API but after working more and more with the table, I realized that having access to the list of all flattened columns is pretty useful (especially when building a column toggle sort of component).

I have decided to rename this property to `allColumns` which will now be part of the public API.