### PR TITLE
[FEATURE] Introduce `resizeOnDrag` for column resizing

### DIFF
--- a/addon/components/lt-column-resizer.js
+++ b/addon/components/lt-column-resizer.js
@@ -9,6 +9,7 @@ export default Ember.Component.extend({
   layout,
   classNameBindings: [':lt-column-resizer', 'isResizing'],
   column: null,
+  resizeOnDrag: false,
 
   isResizing: false,
   startWidth: null,
@@ -70,11 +71,16 @@ export default Ember.Component.extend({
       e.preventDefault();
       e.stopPropagation();
 
+      const resizeOnDrag = this.get('resizeOnDrag');
       const $column = this._getColumn();
       const { startX, startWidth } = this.getProperties(['startX', 'startWidth']);
       const width = startWidth + (e.pageX - startX);
 
-      $column.width(`${width}px`);
+      if(resizeOnDrag) {
+        this.set('column.width', `${width}px`);
+      } else {
+        $column.width(`${width}px`);
+      }
     }
   },
 

--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -58,6 +58,15 @@ export default Ember.Mixin.create({
   multiColumnSort: false,
 
   /**
+   * Resize all cells in the column instead of just the header / footer
+   *
+   * @property resizeOnDrag
+   * @type {Boolean}
+   * @default false
+   */
+  resizeOnDrag: false,
+
+  /**
    * @property iconAscending
    * @type {String}
    * @default ''

--- a/addon/templates/components/columns/base.hbs
+++ b/addon/templates/components/columns/base.hbs
@@ -8,5 +8,5 @@
 {{/if}}
 
 {{#if isResizable}}
-  {{lt-column-resizer column=column columnResized=(action 'columnResized')}}
+  {{lt-column-resizer column=column resizeOnDrag=resizeOnDrag columnResized=(action 'columnResized')}}
 {{/if}}

--- a/addon/templates/components/lt-foot.hbs
+++ b/addon/templates/components/lt-foot.hbs
@@ -10,6 +10,7 @@
               table=table
               tableActions=tableActions
               sortIcons=sortIcons
+              resizeOnDrag=resizeOnDrag
               click=(action 'onColumnClick' column)
               doubleClick=(action 'onColumnDoubleClick' column)
               onColumnResized=(action 'onColumnResized')}}

--- a/addon/templates/components/lt-head.hbs
+++ b/addon/templates/components/lt-head.hbs
@@ -22,6 +22,7 @@
               table=table
               tableActions=tableActions
               sortIcons=sortIcons
+              resizeOnDrag=resizeOnDrag
               click=(action 'onColumnClick' column)
               doubleClick=(action 'onColumnDoubleClick' column)
               columnResized=(action 'onColumnResized')}}
@@ -35,6 +36,7 @@
               classNames="lt-sub-column"
               tableActions=tableActions
               sortIcons=sortIcons
+              resizeOnDrag=resizeOnDrag
               click=(action 'onColumnClick' column)
               doubleClick=(action 'onColumnDoubleClick' column)
               columnResized=(action 'onColumnResized')}}


### PR DESCRIPTION
Fixes regression introduced in 1.2.0. 

Resize all cells in the column instead of just the header / footer