### PR TITLE
[DOCS] fix confusing property names for lt-body

### DIFF
--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -196,7 +196,7 @@ export default Component.extend({
    *    {{t.body spannedRowComponent=(component 'my-spanned-row')}}
    * {{/light-table}}
    * ```
-   * @property rowComponent
+   * @property spannedRowComponent
    * @type {Ember.Component}
    * @default null
    */
@@ -210,7 +210,7 @@ export default Component.extend({
    *    {{t.body infinityComponent=(component 'my-infinity')}}
    * {{/light-table}}
    * ```
-   * @property rowComponent
+   * @property infinityComponent
    * @type {Ember.Component}
    * @default null
    */


### PR DESCRIPTION
no issue
- the three different types of row components were all named the same in the documentation