### PR TITLE
Send row selection state changes to the onRowClick handler

### DIFF
--- a/tests/integration/components/lt-body-test.js
+++ b/tests/integration/components/lt-body-test.js
@@ -149,12 +149,18 @@ test('row expansion - multiple', function(assert) {
 });
 
 test('row actions', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   this.set('table', new Table(Columns, createUsers(1)));
-  this.on('onRowClick', row => assert.ok(row));
+  this.set('canSelect', true);
+
+  this.on('onRowClick', (row, e, affectedSelections)  => {
+      assert.ok(row);
+      assert.equal(affectedSelections.length, 1);
+  });
+
   this.on('onRowDoubleClick', row => assert.ok(row));
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions onRowClick=(action 'onRowClick') onRowDoubleClick=(action 'onRowDoubleClick')}}`);
+  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect onRowClick=(action 'onRowClick') onRowDoubleClick=(action 'onRowDoubleClick')}}`);
 
   let row = this.$('tr:first');
   row.click();


### PR DESCRIPTION
This is my stab at one of the changes I proposed in #151.  The onRowClick action will now send an array of rows whose selection state has been changed as its third parameter. This should allow for easier handling of row selection changes that originate from row clicks, instead of having to setup an observer on `table.selectedRows`, especially if you need to persist the state changes externally, such as to a backend.