### PR TITLE
Proxyable row options

### DIFF
--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
+import globalOptions from 'ember-light-table/-private/global-options';
 
  /**
   * @module Table
   * @class Row
   */
-export default class Row extends Ember.ObjectProxy.extend({
+class Row extends Ember.ObjectProxy.extend({
   /**
    * @property hidden
    * @type {Boolean}
@@ -59,3 +60,13 @@ export default class Row extends Ember.ObjectProxy.extend({
     }
   }
 }
+
+if (!globalOptions.proxyRowOptions) {
+  Row.reopen({
+    hidden: false,
+    expanded: false,
+    selected: false
+  });
+}
+
+export default Row;

--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -8,23 +8,20 @@ export default class Row extends Ember.ObjectProxy.extend({
   /**
    * @property hidden
    * @type {Boolean}
-   * @default false
+   * @default undefined
    */
-  hidden: false,
 
   /**
    * @property expanded
    * @type {Boolean}
-   * @default false
+   * @default undefined
    */
-  expanded: false,
 
   /**
    * @property selected
    * @type {Boolean}
-   * @default false
+   * @default undefined
    */
-  selected: false,
 
   /**
    * Class names to be applied to this row
@@ -40,13 +37,25 @@ export default class Row extends Ember.ObjectProxy.extend({
    * @param {Object} content
    * @param {Object} options
    */
-  constructor(content, options = {}) {
+  constructor(content = {}, options = {}) {
     if (content instanceof Row) {
       return content;
     }
 
     super();
-    this.setProperties(options);
     this.set('content', content);
+    this.setProperties(options);
+
+    if (Ember.isNone(this.get('hidden'))) {
+      this.set('hidden', false);
+    }
+
+    if (Ember.isNone(this.get('expanded'))) {
+      this.set('expanded', false);
+    }
+
+    if (Ember.isNone(this.get('selected'))) {
+      this.set('selected', false);
+    }
   }
 }

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -176,7 +176,7 @@ export default Component.extend({
 
   /**
    * Allows to customize the component used to render rows
-   * 
+   *
    * ```hbs
    * {{#light-table table as |t|}}
    *    {{t.body rowComponent=(component 'my-row')}}
@@ -204,7 +204,7 @@ export default Component.extend({
 
   /**
    * Allows to customize the component used to render infinite loader
-   * 
+   *
    * ```hbs
    * {{#light-table table as |t|}}
    *    {{t.body infinityComponent=(component 'my-infinity')}}
@@ -241,7 +241,7 @@ export default Component.extend({
 
   toggleExpandedRow(row) {
     let multi = this.get('multiRowExpansion');
-    let shouldExpand = !row.expanded;
+    let shouldExpand = !row.get('expanded');
 
     if (multi) {
       row.toggleProperty('expanded');

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,9 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+    'ember-light-table': {
+        proxyRowOptions: true
     }
   };
 

--- a/tests/integration/components/lt-body-test.js
+++ b/tests/integration/components/lt-body-test.js
@@ -93,6 +93,18 @@ test('row selection - click to modify selection', function(assert) {
   assert.equal(this.$('tr.is-selected').length, 5, 'clicking a deselected row selects it without affecting other selected rows');
 });
 
+test('row selection - preselected rows', function(assert) {
+  let users = createUsers(1);
+  users[0].selected = true;
+  this.set('table', new Table(Columns, users));
+  this.set('canSelect', true);
+
+  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect}}`);
+
+  let row = this.$('tr:first');
+  assert.ok(row.hasClass('is-selected'));
+});
+
 test('row expansion', function(assert) {
   this.set('table', new Table(Columns, createUsers(2)));
   this.set('canExpand', false);
@@ -148,6 +160,23 @@ test('row expansion - multiple', function(assert) {
   assert.equal(this.$('tr.lt-expanded-row').length, 2);
 });
 
+test('row expansion - pre-expanded rows', function(assert) {
+  let users = createUsers(1);
+  users[0].expanded = true;
+  this.set('table', new Table(Columns, users));
+  this.render(hbs `
+    {{#lt-body table=table sharedOptions=sharedOptions canExpand=true as |b|}}
+      {{#b.expanded-row}} Hello {{/b.expanded-row}}
+    {{/lt-body}}
+  `);
+
+  let row = this.$('tr:first');
+  assert.equal(this.$('tr.lt-expanded-row').length, 1);
+
+  row.click();
+  assert.equal(this.$('tr.lt-expanded-row').length, 0);
+});
+
 test('row actions', function(assert) {
   assert.expect(2);
 
@@ -180,6 +209,22 @@ test('hidden rows', function(assert) {
   });
 
   assert.equal(this.$('tbody > tr').length, 4);
+});
+
+test('pre-hidden rows', function(assert) {
+  let users = createUsers(1);
+  users[0].hidden = true;
+  this.set('table', new Table(Columns, users));
+
+  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions}}`);
+
+  assert.equal(this.$('tbody > tr').length, 0);
+
+  run(() => {
+    this.get('table.rows').objectAt(0).set('hidden', false);
+  });
+
+  assert.equal(this.$('tbody > tr').length, 1);
 });
 
 test('overwrite', function(assert) {

--- a/tests/unit/classes/row-test.js
+++ b/tests/unit/classes/row-test.js
@@ -6,8 +6,8 @@ module('Unit | Classes | Row');
 test('create row - default options', function(assert) {
   let row = new Row();
   assert.ok(row);
-  assert.equal(row.expanded, false);
-  assert.equal(row.selected, false);
+  assert.equal(row.get('expanded'), false);
+  assert.equal(row.get('selected'), false);
 });
 
 test('create row - row instance', function(assert) {


### PR DESCRIPTION
An attempt at solving the problem discussed in #151, allowing row options/state properties (notably, the `selected` state) to be proxied to the row's content object. However, this PR feels kinda messy/ugly and probably is not the best implementation, so its more intended as a way to kick off further discussion and ideas.

A major thing to point out is that I ended up requiring a global option, `proxyRowOptions` to be enabled in order to opt-in to the proxying of the row options. I did this because I think without it, this would be a potentially breaking change to the API, since setting the row's `hidden`, `expanded`, and `selected` properties are now updating the row's content object itself, which may already contain properties with the same name that are used for other purposes.