### PR TITLE
Docfix: lt-head and column-type blueprint

### DIFF
--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -24,7 +24,7 @@ const {
  *
  * ```hbs
  * {{#light-table table as |t|}}
- *   {{#t.head onColumnClick=(action 'sortByColumn') as |groups subColumns table|}}
+ *   {{#t.head onColumnClick=(action 'sortByColumn') as |groups subColumns|}}
  *     {{#each groups as |group|}}
  *       {{!-- ... --}}
  *     {{/each}}

--- a/blueprints/column-type/index.js
+++ b/blueprints/column-type/index.js
@@ -1,4 +1,4 @@
 /*jshint node:true*/
 module.exports = {
-  description: 'Generates a cell type and integration test'
+  description: 'Generates a column type and integration test'
 };


### PR DESCRIPTION
closes https://github.com/offirgolan/ember-light-table/issues/198