### PR TITLE
(docs): Namespacing the classes

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -8,6 +8,7 @@ const {
 
  /**
   * @module Table
+  * @namespace LightTable
   * @class Column
   */
 export default class Column extends Ember.Object.extend({

--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
  /**
   * @module Table
+  * @namespace LightTable
   * @class Row
   */
 export default class Row extends Ember.ObjectProxy.extend({

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -30,6 +30,7 @@ const RowSyncArrayProxy = SyncArrayProxy.extend({
  /**
   * @module Table
   * @class Table
+  * @namespace LightTable
   */
 export default class Table extends Ember.Object.extend({
   /**


### PR DESCRIPTION
Looks like so.
![image](https://cloud.githubusercontent.com/assets/11779993/19130700/5737e4cc-8b1a-11e6-96e7-3227dc5d4141.png)

That way people can import: http://offirgolan.github.io/ember-light-table/docs/data.json into their yuidoc.json externals, and not get their classes clobbered.

Wondering if I should namespace all the components?
