### PR TITLE
Upgraded ember-scrollable to 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-composable-helpers": "^1.1.2",
     "ember-get-config": "0.1.9",
     "ember-in-viewport": "2.1.0",
-    "ember-scrollable": "0.3.2",
+    "ember-scrollable": "0.3.3",
     "ember-truth-helpers": "1.2.0",
     "ember-wormhole": "0.4.0"
   },


### PR DESCRIPTION
0.3.3 upgrade makes the tests run faster by removing autohide delay from `ember-scrollable`