### PR TITLE
[FEATURE] Add label to base column to be used in column types

### DIFF
--- a/addon/components/columns/base.js
+++ b/addon/components/columns/base.js
@@ -37,7 +37,13 @@ const Column = Component.extend({
 
   align: computed('column.align', function () {
     return `align-${this.get('column.align')}`;
-  }).readOnly(),
+  }),
+
+  /**
+   * @property label
+   * @type {String}
+   */
+  label: computed.oneWay('column.label'),
 
   /**
    * @property table

--- a/addon/templates/components/columns/base.hbs
+++ b/addon/templates/components/columns/base.hbs
@@ -1,7 +1,7 @@
 {{#if column.component}}
   {{component column.component column=column table=table tableActions=tableActions sortIcons=sortIcons}}
 {{else}}
-  {{column.label}}
+  {{label}}
   {{#if column.sorted}}
     <span class="lt-sort-icon {{if column.ascending sortIcons.iconAscending sortIcons.iconDescending}}"></span>
   {{/if}}


### PR DESCRIPTION
This puts `label` on the base column so it can be easily overwritten when defining new column types. 