### PR TITLE
[FEATURE] Responsive Columns

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -26,6 +26,14 @@ export default class Column extends Ember.Object.extend({
   hidden: false,
 
   /**
+   * If true, this column has been hidden due to the responsive behavior
+   * @property responsiveHidden
+   * @type {Boolean}
+   * @default false
+   */
+  responsiveHidden: false,
+
+  /**
    * @property ascending
    * @type {Boolean}
    * @default true
@@ -76,6 +84,27 @@ export default class Column extends Ember.Object.extend({
    * @optional
    */
   subColumns: null,
+
+  /**
+   * An array of media breakpoints that determine when this column will be shown
+   *
+   * If we have the following breakpoints defined in `app/breakpoints.js`:
+   *
+   * - mobile
+   * - tablet
+   * - desktop
+   *
+   * And we want to show this column only for tablet and dekstop media, the following
+   * array should be specified: `['tablet', 'desktop']`.
+   *
+   * If this property is `null`, `undefined`, or `[]`, then this column will always
+   * be shown, regardless of the current media type.
+   *
+   * @property breakpoints
+   * @type {Array}
+   * @optional
+   */
+  breakpoints: null,
 
   /**
    * Type of column component
@@ -163,11 +192,20 @@ export default class Column extends Ember.Object.extend({
   cellClassNames: null,
 
   /**
-   * A format function used to calculate a cell's value
+   * A format function used to calculate a cell's value. This method will be passed
+   * the raw value if `valuePath` is specified.
+   *
    * @property format
    * @type {Function}
    */
   format: null,
+
+  /**
+   * True if `hidden` or `responsiveHidden` is true.
+   * @property isHidden
+   * @type {Boolean}
+   */
+  isHidden: computed.or('hidden', 'responsiveHidden').readOnly(),
 
   /**
    * @property isGroupColumn
@@ -181,8 +219,8 @@ export default class Column extends Ember.Object.extend({
    * @type {Boolean}
    * @private
    */
-  isVisibleGroupColumn: computed('visibleSubColumns.[]', 'hidden', function() {
-    return !isEmpty(this.get('visibleSubColumns')) && !this.get('hidden');
+  isVisibleGroupColumn: computed('visibleSubColumns.[]', 'isHidden', function() {
+    return !isEmpty(this.get('visibleSubColumns')) && !this.get('isHidden');
   }).readOnly(),
 
   /**
@@ -190,9 +228,9 @@ export default class Column extends Ember.Object.extend({
    * @type {Array}
    * @private
    */
-  visibleSubColumns: computed('subColumns.[]', 'subColumns.@each.hidden', 'hidden', function() {
+  visibleSubColumns: computed('subColumns.[]', 'subColumns.@each.isHidden', 'isHidden', function() {
     let subColumns = this.get('subColumns');
-    return isEmpty(subColumns) || this.get('hidden') ? [] : subColumns.filterBy('hidden', false);
+    return isEmpty(subColumns) || this.get('isHidden') ? [] : subColumns.filterBy('isHidden', false);
   }).readOnly()
 }) {
   /**

--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -94,7 +94,7 @@ export default class Column extends Ember.Object.extend({
    * - tablet
    * - desktop
    *
-   * And we want to show this column only for tablet and dekstop media, the following
+   * And we want to show this column only for tablet and desktop media, the following
    * array should be specified: `['tablet', 'desktop']`.
    *
    * If this property is `null`, `undefined`, or `[]`, then this column will always

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -95,18 +95,24 @@ export default class Table extends Ember.Object.extend({
   hiddenColumns: computed.filterBy('allColumns', 'hidden', true).readOnly(),
 
   /**
+   * @property responsiveHiddenColumns
+   * @type {Ember.Array}
+   */
+  responsiveHiddenColumns: computed.filterBy('allColumns', 'responsiveHidden', true).readOnly(),
+
+  /**
    * @property visibleColumns
    * @type {Ember.Array}
    */
-  visibleColumns: computed.filterBy('allColumns', 'hidden', false).readOnly(),
+  visibleColumns: computed.filterBy('allColumns', 'isHidden', false).readOnly(),
 
   /**
    * @property visibleColumnGroups
    * @type {Ember.Array}
    */
-  visibleColumnGroups: computed('columns.[]', 'columns.@each.{hidden,isVisibleGroupColumn}', function() {
+  visibleColumnGroups: computed('columns.[]', 'columns.@each.{isHidden,isVisibleGroupColumn}', function() {
     return emberArray(this.get('columns').reduce((arr, c) => {
-      if (c.get('isVisibleGroupColumn') || (!c.get('isGroupColumn') && !c.get('hidden'))) {
+      if (c.get('isVisibleGroupColumn') || (!c.get('isGroupColumn') && !c.get('isHidden'))) {
         arr.push(c);
       }
       return arr;

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -160,7 +160,15 @@ const LightTable = Component.extend({
 
   init() {
     this._super(...arguments);
-    assert('[ember-light-table] table must be an instance of Table', this.get('table') instanceof Table);
+
+    let table = this.get('table');
+    let media = this.get('media');
+
+    assert('[ember-light-table] table must be an instance of Table', table instanceof Table);
+
+    if (isNone(media)) {
+      this.set('responsive', false);
+    }
   },
 
   destroy() {

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -13,7 +13,6 @@ const {
   on,
   isNone,
   isEmpty,
-  run,
   A: emberArray
 } = Ember;
 
@@ -171,11 +170,6 @@ const LightTable = Component.extend({
     }
   },
 
-  destroy() {
-    this._super(...arguments);
-    run.cancel(this._breakpointChangeTimer);
-  },
-
   onMediaChange: on('init', observer('media.matches.[]', 'table.allColumns.[]', function() {
     let responsive = this.get('responsive');
     let matches = this.get('media.matches');
@@ -198,16 +192,12 @@ const LightTable = Component.extend({
     } else {
       table.get('allColumns').forEach((c) => {
         let breakpoints = c.get('breakpoints');
-
-        if (isEmpty(breakpoints) || intersections(matches, breakpoints).length > 0) {
-          c.set('responsiveHidden', false);
-        } else {
-          c.set('responsiveHidden', true);
-        }
+        let isMatch = isEmpty(breakpoints) || intersections(matches, breakpoints).length > 0;
+        c.set('responsiveHidden', !isMatch);
       });
     }
 
-    this._breakpointChangeTimer = run.next(this, 'send', 'onBreakpointChange', matches);
+    this.send('onBreakpointChange', matches);
   })),
 
   _displayColumns(numColumns) {

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -181,6 +181,8 @@ const LightTable = Component.extend({
       return;
     }
 
+    this.send('onBeforeResponsiveChange', matches);
+
     if (!isNone(breakpoints)) {
       Object.keys(breakpoints).forEach((b) => {
         if (matches.indexOf(b) > -1) {
@@ -197,7 +199,7 @@ const LightTable = Component.extend({
       });
     }
 
-    this.send('onBreakpointChange', matches);
+    this.send('onAfterResponsiveChange', matches);
   })),
 
   _displayColumns(numColumns) {
@@ -216,12 +218,25 @@ const LightTable = Component.extend({
 
   actions: {
     /**
-     * onBreakpointChange action.
-     * @event onBreakpointChange
+     * onBeforeResponsiveChange action.
+     * Called before any column visibility is altered.
+     *
+     * @event onBeforeResponsiveChange
      * @param  {Array} matches list of matching breakpoints
      */
-    onBreakpointChange(/* matches */) {
-      callAction(this, 'onBreakpointChange', ...arguments);
+    onBeforeResponsiveChange(/* matches */) {
+      callAction(this, 'onBeforeResponsiveChange', ...arguments);
+    },
+
+    /**
+     * onAfterResponsiveChange action.
+     * Called after all column visibility has been altered.
+     *
+     * @event onAfterResponsiveChange
+     * @param  {Array} matches list of matching breakpoints
+     */
+    onAfterResponsiveChange(/* matches */) {
+      callAction(this, 'onAfterResponsiveChange', ...arguments);
     }
   }
 });

--- a/blueprints/ember-light-table/index.js
+++ b/blueprints/ember-light-table/index.js
@@ -1,0 +1,10 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Install Ember Light Table dependencies',
+
+  normalizeEntityName: function() {},
+
+  beforeInstall: function() {
+    return this.addAddonToProject('ember-responsive');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-lodash": "0.0.10",
     "ember-owner-test-utils": "0.1.1",
     "ember-resolver": "^2.0.3",
+    "ember-responsive": "2.0.0",
     "ember-suave": "4.0.1",
     "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.1",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,5 +1,6 @@
 {
   "predef": [
+    "setBreakpoint",
     "server",
     "document",
     "window",

--- a/tests/dummy/app/breakpoints.js
+++ b/tests/dummy/app/breakpoints.js
@@ -1,0 +1,6 @@
+export default {
+  xs:  '(max-width: 767px)',
+  sm:  '(min-width: 768px) and (max-width: 991px)',
+  md:  '(min-width: 992px) and (max-width: 1199px)',
+  lg:  '(min-width: 1200px)'
+};

--- a/tests/dummy/app/controllers/responsive.js
+++ b/tests/dummy/app/controllers/responsive.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+import TableController from './table';
+
+const {
+  computed
+} = Ember;
+
+export default TableController.extend({
+  columns: computed(function() {
+    return [{
+      label: 'Avatar',
+      valuePath: 'avatar',
+      width: '60px',
+      sortable: false,
+      cellComponent: 'user-avatar'
+    }, {
+      label: 'First Name',
+      valuePath: 'firstName',
+      width: '150px',
+      breakpoints: ['xs', 'sm', 'md', 'lg']
+    }, {
+      label: 'Last Name',
+      valuePath: 'lastName',
+      width: '150px',
+      breakpoints: ['xs', 'sm', 'md', 'lg']
+    }, {
+      label: 'Address',
+      valuePath: 'address',
+      breakpoints: ['sm', 'md', 'lg']
+    }, {
+      label: 'State',
+      valuePath: 'state',
+      breakpoints: ['md', 'lg']
+    }, {
+      label: 'Country',
+      valuePath: 'country',
+      breakpoints: ['lg']
+    }];
+  })
+});

--- a/tests/dummy/app/controllers/responsive.js
+++ b/tests/dummy/app/controllers/responsive.js
@@ -8,6 +8,11 @@ const {
 export default TableController.extend({
   columns: computed(function() {
     return [{
+      width: '40px',
+      sortable: false,
+      cellComponent: 'row-toggle',
+      breakpoints: ['xs', 'sm', 'md']
+    }, {
       label: 'Avatar',
       valuePath: 'avatar',
       width: '60px',
@@ -16,13 +21,12 @@ export default TableController.extend({
     }, {
       label: 'First Name',
       valuePath: 'firstName',
-      width: '150px',
-      breakpoints: ['xs', 'sm', 'md', 'lg']
+      width: '150px'
     }, {
       label: 'Last Name',
       valuePath: 'lastName',
       width: '150px',
-      breakpoints: ['xs', 'sm', 'md', 'lg']
+      breakpoints: ['sm', 'md', 'lg']
     }, {
       label: 'Address',
       valuePath: 'address',
@@ -36,5 +40,13 @@ export default TableController.extend({
       valuePath: 'country',
       breakpoints: ['lg']
     }];
-  })
+  }),
+
+  actions: {
+    onBreakpointChange(matches) {
+      if (matches.indexOf('lg') > -1) {
+        this.get('table.expandedRows').setEach('expanded', false);
+      }
+    }
+  }
 });

--- a/tests/dummy/app/controllers/responsive.js
+++ b/tests/dummy/app/controllers/responsive.js
@@ -43,7 +43,7 @@ export default TableController.extend({
   }),
 
   actions: {
-    onBreakpointChange(matches) {
+    onAfterResponsiveChange(matches) {
       if (matches.indexOf('lg') > -1) {
         this.get('table.expandedRows').setEach('expanded', false);
       }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('expandable');
   this.route('selectable');
   this.route('resizable');
+  this.route('responsive');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/responsive.js
+++ b/tests/dummy/app/routes/responsive.js
@@ -1,0 +1,1 @@
+export { default } from './table-route';

--- a/tests/dummy/app/styles/app.less
+++ b/tests/dummy/app/styles/app.less
@@ -163,6 +163,15 @@ html,body {
   border: 1px solid #ccc;
 }
 
+.row-toggle {
+  color: @accent-color;
+  cursor: pointer;
+
+  &:hover, &:active, &:focus {
+    color: darken(@accent-color, 5%)
+  }
+}
+
 .tip {
   text-align: center;
   font-size: 13px;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -21,18 +21,30 @@
         {{#link-to 'responsive' tagName="li"}}
           {{link-to 'Responsive' 'responsive'}}
         {{/link-to}}
-        {{#link-to 'grouped' tagName="li"}}
-          {{link-to 'Grouped Columns' 'grouped'}}
-        {{/link-to}}
-        {{#link-to 'resizable' tagName="li"}}
-          {{link-to 'Resizable Columns' 'resizable'}}
-        {{/link-to}}
-        {{#link-to 'expandable' tagName="li"}}
-          {{link-to 'Expandable Rows' 'expandable'}}
-        {{/link-to}}
-        {{#link-to 'selectable' tagName="li"}}
-          {{link-to 'Selectable Rows' 'selectable'}}
-        {{/link-to}}
+
+        <li class='dropdown'>
+          <a class='dropdown-toggle' data-toggle='dropdown' role='button' aria-haspopup='true' aria-expanded='false'>Columns <span class='fa fa-caret-down'></span></a>
+          <ul class='nav navbar-nav dropdown-menu'>
+            {{#link-to 'grouped' tagName="li"}}
+              {{link-to 'Grouped Columns' 'grouped'}}
+            {{/link-to}}
+            {{#link-to 'resizable' tagName="li"}}
+              {{link-to 'Resizable Columns' 'resizable'}}
+            {{/link-to}}
+          </ul>
+        </li>
+
+        <li class='dropdown'>
+          <a class='dropdown-toggle' data-toggle='dropdown' role='button' aria-haspopup='true' aria-expanded='false'>Rows <span class='fa fa-caret-down'></span></a>
+          <ul class='nav navbar-nav dropdown-menu'>
+            {{#link-to 'expandable' tagName="li"}}
+              {{link-to 'Expandable Rows' 'expandable'}}
+            {{/link-to}}
+            {{#link-to 'selectable' tagName="li"}}
+              {{link-to 'Selectable Rows' 'selectable'}}
+            {{/link-to}}
+          </ul>
+        </li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li><a href="docs">Documentation</a></li>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -18,6 +18,9 @@
         {{#link-to 'index' tagName="li"}}
           {{link-to 'Home' 'index'}}
         {{/link-to}}
+        {{#link-to 'responsive' tagName="li"}}
+          {{link-to 'Responsive' 'responsive'}}
+        {{/link-to}}
         {{#link-to 'grouped' tagName="li"}}
           {{link-to 'Grouped Columns' 'grouped'}}
         {{/link-to}}

--- a/tests/dummy/app/templates/components/responsive-expanded-row.hbs
+++ b/tests/dummy/app/templates/components/responsive-expanded-row.hbs
@@ -1,0 +1,10 @@
+{{!-- BEGIN-SNIPPET responsive-expanded-row --}}
+<div class="row">
+  <dl class="dl-horizontal">
+    {{#each table.responsiveHiddenColumns as |column|}}
+        <dt>{{column.label}}:</dt>
+        <dd>{{get row column.valuePath}}</dd>
+    {{/each}}
+  </dl>
+</div>
+{{!-- END-SNIPPET --}}

--- a/tests/dummy/app/templates/components/row-toggle.hbs
+++ b/tests/dummy/app/templates/components/row-toggle.hbs
@@ -1,0 +1,5 @@
+{{!-- BEGIN-SNIPPET row-toggle --}}
+<a class="row-toggle" {{action (toggle 'expanded' row)}}>
+  <i class="fa {{if row.expanded 'fa-chevron-down' 'fa-chevron-right'}}"></i>
+</a>
+{{!-- END-SNIPPET --}}

--- a/tests/dummy/app/templates/responsive.hbs
+++ b/tests/dummy/app/templates/responsive.hbs
@@ -2,7 +2,7 @@
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="table-1">
       <a role="button" data-toggle="collapse" data-parent="#accordion" href="#code-snippet" aria-expanded="true" aria-controls="code-snippet">
-        <h4 class="panel-title">Simple Example <span class="code-icon fa fa-code pull-right"></span></h4>
+        <h4 class="panel-title">Responsive Example <span class="code-icon fa fa-code pull-right"></span></h4>
       </a>
     </div>
     <div id="code-snippet" class="panel-collapse collapse" role="tabpanel" aria-labelledby="table-1">
@@ -10,20 +10,29 @@
        <ul class="nav nav-tabs" role="tablist">
          <li role="presentation" class="active"><a href="#component" aria-controls="component" role="tab" data-toggle="tab">component.js</a></li>
          <li role="presentation"><a href="#template" aria-controls="template" role="tab" data-toggle="tab">template.hbs</a></li>
+         <li role="presentation"><a href="#responsive-expanded-row" aria-controls="responsive-expanded-row" role="tab" data-toggle="tab">responsive-expanded-row.hbs</a></li>
          <li role="presentation"><a href="#user-avatar" aria-controls="user-avatar" role="tab" data-toggle="tab">user-avatar.hbs</a></li>
          <li role="presentation"><a href="#table-loader" aria-controls="table-loader" role="tab" data-toggle="tab">table-loader.hbs</a></li>
+         <li role="presentation"><a href="#row-toggle" aria-controls="row-toggle" role="tab" data-toggle="tab">row-toggle.hbs</a></li>
        </ul>
        <div class="tab-content">
-         <div role="tabpanel" class="tab-pane fade in active" id="component">{{code-snippet name="simple-table.js"}}</div>
-         <div role="tabpanel" class="tab-pane fade" id="template">{{code-snippet name="simple-table.hbs"}}</div>
+         <div role="tabpanel" class="tab-pane fade in active" id="component">{{code-snippet name="responsive-table.js"}}</div>
+         <div role="tabpanel" class="tab-pane fade" id="template">{{code-snippet name="responsive-table.hbs"}}</div>
+         <div role="tabpanel" class="tab-pane fade" id="responsive-expanded-row">{{code-snippet name="responsive-expanded-row.hbs"}}</div>
          <div role="tabpanel" class="tab-pane fade" id="user-avatar">{{code-snippet name="user-avatar.hbs"}}</div>
          <div role="tabpanel" class="tab-pane fade" id="table-loader">{{code-snippet name="table-loader.hbs"}}</div>
+         <div role="tabpanel" class="tab-pane fade" id="row-toggle">{{code-snippet name="row-toggle.hbs"}}</div>
        </div>
       </div>
     </div>
     <div class="panel-body table-container">
-{{!-- BEGIN-SNIPPET simple-table --}}
-{{#light-table table responsive=true height='65vh' as |t|}}
+{{!-- BEGIN-SNIPPET responsive-table --}}
+{{#light-table table
+  height='65vh'
+  responsive=true
+  onBreakpointChange=(action 'onBreakpointChange')
+  as |t|
+}}
 
   {{t.head
     onColumnClick=(action 'onColumnClick')
@@ -34,9 +43,14 @@
 
   {{#t.body
     canSelect=false
+    expandOnClick=false
     onScrolledToBottom=(action 'onScrolledToBottom')
     as |body|
   }}
+    {{#body.expanded-row as |row|}}
+      {{responsive-expanded-row table=table row=row}}
+    {{/body.expanded-row}}
+
     {{#if isLoading}}
       {{#body.loader}}
         {{table-loader}}

--- a/tests/dummy/app/templates/responsive.hbs
+++ b/tests/dummy/app/templates/responsive.hbs
@@ -30,7 +30,7 @@
 {{#light-table table
   height='65vh'
   responsive=true
-  onBreakpointChange=(action 'onBreakpointChange')
+  onAfterResponsiveChange=(action 'onAfterResponsiveChange')
   as |t|
 }}
 

--- a/tests/dummy/app/templates/responsive.hbs
+++ b/tests/dummy/app/templates/responsive.hbs
@@ -1,0 +1,51 @@
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="table-1">
+      <a role="button" data-toggle="collapse" data-parent="#accordion" href="#code-snippet" aria-expanded="true" aria-controls="code-snippet">
+        <h4 class="panel-title">Simple Example <span class="code-icon fa fa-code pull-right"></span></h4>
+      </a>
+    </div>
+    <div id="code-snippet" class="panel-collapse collapse" role="tabpanel" aria-labelledby="table-1">
+      <div class="panel-body code-snippet">
+       <ul class="nav nav-tabs" role="tablist">
+         <li role="presentation" class="active"><a href="#component" aria-controls="component" role="tab" data-toggle="tab">component.js</a></li>
+         <li role="presentation"><a href="#template" aria-controls="template" role="tab" data-toggle="tab">template.hbs</a></li>
+         <li role="presentation"><a href="#user-avatar" aria-controls="user-avatar" role="tab" data-toggle="tab">user-avatar.hbs</a></li>
+         <li role="presentation"><a href="#table-loader" aria-controls="table-loader" role="tab" data-toggle="tab">table-loader.hbs</a></li>
+       </ul>
+       <div class="tab-content">
+         <div role="tabpanel" class="tab-pane fade in active" id="component">{{code-snippet name="simple-table.js"}}</div>
+         <div role="tabpanel" class="tab-pane fade" id="template">{{code-snippet name="simple-table.hbs"}}</div>
+         <div role="tabpanel" class="tab-pane fade" id="user-avatar">{{code-snippet name="user-avatar.hbs"}}</div>
+         <div role="tabpanel" class="tab-pane fade" id="table-loader">{{code-snippet name="table-loader.hbs"}}</div>
+       </div>
+      </div>
+    </div>
+    <div class="panel-body table-container">
+{{!-- BEGIN-SNIPPET simple-table --}}
+{{#light-table table responsive=true height='65vh' as |t|}}
+
+  {{t.head
+    onColumnClick=(action 'onColumnClick')
+    iconAscending='fa fa-sort-asc'
+    iconDescending='fa fa-sort-desc'
+    fixed=true
+  }}
+
+  {{#t.body
+    canSelect=false
+    onScrolledToBottom=(action 'onScrolledToBottom')
+    as |body|
+  }}
+    {{#if isLoading}}
+      {{#body.loader}}
+        {{table-loader}}
+      {{/body.loader}}
+    {{/if}}
+  {{/t.body}}
+
+{{/light-table}}
+{{!-- END-SNIPPET --}}
+    </div>
+  </div>
+</div>

--- a/tests/dummy/snippets/responsive-table.js
+++ b/tests/dummy/snippets/responsive-table.js
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
 
   actions: {
     onScrolledToBottom() {
-      if(this.get('canLoadMore')) {
+      if (this.get('canLoadMore')) {
         this.incrementProperty('page');
         this.fetchRecords();
       }
@@ -81,7 +81,7 @@ export default Ember.Component.extend({
       }
     },
 
-    onBreakpointChange(matches) {
+    onAfterResponsiveChange(matches) {
       if (matches.indexOf('lg') > -1) {
         this.get('table.expandedRows').setEach('expanded', false);
       }

--- a/tests/dummy/snippets/responsive-table.js
+++ b/tests/dummy/snippets/responsive-table.js
@@ -1,0 +1,90 @@
+import Ember from 'ember';
+import Table from 'ember-light-table';
+
+const { isEmpty, computed } = Ember;
+
+export default Ember.Component.extend({
+  page: 1,
+  limit: 20,
+  dir: 'asc',
+  sort: null,
+  model: null,
+  isLoading: false,
+  canLoadMore: true,
+
+  columns: computed(function() {
+    return [{
+      width: '40px',
+      sortable: false,
+      cellComponent: 'row-toggle',
+      breakpoints: ['xs', 'sm', 'md']
+    }, {
+      label: 'Avatar',
+      valuePath: 'avatar',
+      width: '60px',
+      sortable: false,
+      cellComponent: 'user-avatar'
+    }, {
+      label: 'First Name',
+      valuePath: 'firstName',
+      width: '150px'
+    }, {
+      label: 'Last Name',
+      valuePath: 'lastName',
+      width: '150px',
+      breakpoints: ['sm', 'md', 'lg']
+    }, {
+      label: 'Address',
+      valuePath: 'address',
+      breakpoints: ['sm', 'md', 'lg']
+    }, {
+      label: 'State',
+      valuePath: 'state',
+      breakpoints: ['md', 'lg']
+    }, {
+      label: 'Country',
+      valuePath: 'country',
+      breakpoints: ['lg']
+    }];
+  }),
+
+  table: computed('model', function() {
+    return new Table(this.get('columns'), this.get('model'), { enableSync: true });
+  }),
+
+  fetchRecords() {
+    this.set('isLoading', true);
+    this.store.query('user', this.getProperties(['page', 'limit', 'sort', 'dir'])).then(records => {
+      this.get('model').pushObjects(records.toArray());
+      this.set('isLoading', false);
+      this.set('canLoadMore', !isEmpty(records));
+    });
+  },
+
+  actions: {
+    onScrolledToBottom() {
+      if(this.get('canLoadMore')) {
+        this.incrementProperty('page');
+        this.fetchRecords();
+      }
+    },
+
+    onColumnClick(column) {
+      if (column.sorted) {
+        this.setProperties({
+          dir: column.ascending ? 'asc' : 'desc',
+          sort: column.get('valuePath'),
+          page: 1
+        });
+        this.get('model').clear();
+        this.fetchRecords();
+      }
+    },
+
+    onBreakpointChange(matches) {
+      if (matches.indexOf('lg') > -1) {
+        this.get('table.expandedRows').setEach('expanded', false);
+      }
+    }
+  }
+});

--- a/tests/helpers/responsive.js
+++ b/tests/helpers/responsive.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+import MediaService from 'ember-responsive/media';
+
+const { K, getOwner } = Ember;
+const { classify } = Ember.String;
+
+MediaService.reopen({
+  // Change this if you want a different default breakpoint in tests.
+  _defaultBreakpoint: 'desktop',
+
+  _breakpointArr: Ember.computed('breakpoints', function() {
+    return Object.keys(this.get('breakpoints')) || Ember.A([]);
+  }),
+
+  _forceSetBreakpoint(breakpoint) {
+    let found = false;
+
+    const props = {};
+    this.get('_breakpointArr').forEach(function(bp) {
+      const val = bp === breakpoint;
+      if (val) {
+        found = true;
+      }
+
+      props[`is${classify(bp)}`] = val;
+    });
+
+    if (found) {
+      this.setProperties(props);
+    } else {
+      throw new Error(
+        `You tried to set the breakpoint to ${breakpoint}, which is not in your app/breakpoint.js file.`
+      );
+    }
+  },
+
+  match: K, // do not set up listeners in test
+
+  init() {
+    this._super(...arguments);
+
+    this._forceSetBreakpoint(this.get('_defaultBreakpoint'));
+  }
+});
+
+export default Ember.Test.registerAsyncHelper('setBreakpoint', function(app, breakpoint) {
+  // this should use getOwner once that's supported
+  const mediaService = app.__deprecatedInstance__.lookup('service:media');
+  mediaService._forceSetBreakpoint(breakpoint);
+});
+
+export function setBreakpointForIntegrationTest(container, breakpoint) {
+  const mediaService = getOwner(container).lookup('service:media');
+  mediaService._forceSetBreakpoint(breakpoint);
+  container.set('media', mediaService);
+
+  return mediaService;
+}

--- a/tests/helpers/responsive.js
+++ b/tests/helpers/responsive.js
@@ -15,9 +15,9 @@ MediaService.reopen({
   _forceSetBreakpoint(breakpoint) {
     let found = false;
 
-    const props = {};
+    let props = {};
     this.get('_breakpointArr').forEach(function(bp) {
-      const val = bp === breakpoint;
+      let val = bp === breakpoint;
       if (val) {
         found = true;
       }
@@ -45,12 +45,12 @@ MediaService.reopen({
 
 export default Ember.Test.registerAsyncHelper('setBreakpoint', function(app, breakpoint) {
   // this should use getOwner once that's supported
-  const mediaService = app.__deprecatedInstance__.lookup('service:media');
+  let mediaService = app.__deprecatedInstance__.lookup('service:media');
   mediaService._forceSetBreakpoint(breakpoint);
 });
 
 export function setBreakpointForIntegrationTest(container, breakpoint) {
-  const mediaService = getOwner(container).lookup('service:media');
+  let mediaService = getOwner(container).lookup('service:media');
   mediaService._forceSetBreakpoint(breakpoint);
   container.set('media', mediaService);
 


### PR DESCRIPTION
Resolves #219. 

This PR introduces a responsive solution. Using [ember-responsive](https://github.com/freshbooks/ember-responsive), I have introduced two methods to handle responsive behaviors that will hide the appropriate columns. This PR also introduces a new table property `responsiveHiddenColumns` to be able to easily distinguish between hidden columns and columns hidden from this responsive behavior.

### Via column definition

Specify an array of media breakpoints that determine when this column will be shown. If we have the following breakpoints defined in `app/breakpoints.js`:

- mobile
- tablet
- desktop

And we want to show this column only for tablet and desktop media, the following array should be specified:

```js
{
  breakpoints: ['tablet', 'desktop']
}
```

If this property is `null`, `undefined`, or `[]`, then this column will always be shown, regardless of the current media type.


### Via light-table component

Pass a hash to determine the number of columns to show per given breakpoint. If this is specified, it will override any column specific breakpoints. If we have the following breakpoints defined in `app/breakpoints.js`:

- mobile
- tablet
- desktop

The following hash can be passed in:

```hbs
{{#light-table table breakpoints=(hash 
  mobile=2
  tablet=4
) as |t|}}

{{/light-table}}
```

If there is no rule specified for a given breakpoint (i.e. `desktop`), all columns will be shown.