### PR TITLE
[BUGFIX] repeated scrollToRow

### DIFF
--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -328,11 +328,13 @@ export default Component.extend({
         targetScrollOffset,
         hasReachedTargetScrollOffset: targetScrollOffset <= 0
       });
-    } else if (scrollToRow !== _scrollToRow && scrollToRow && scrollToRow instanceof Row) {
-      let rowElement = document.getElementById(scrollToRow.get('rowId'));
+    } else if (scrollToRow !== _scrollToRow) {
+      if (scrollToRow instanceof Row) {
+        let rowElement = document.getElementById(scrollToRow.get('rowId'));
 
-      if (rowElement && rowElement instanceof Element) {
-        targetScrollOffset = rowElement.offsetTop;
+        if (rowElement instanceof Element) {
+          targetScrollOffset = rowElement.offsetTop;
+        }
       }
 
       this.setProperties({ targetScrollOffset, hasReachedTargetScrollOffset: true });


### PR DESCRIPTION
Currently repeatedly setting the `scrollToRow` property to the same row doesn't work, because the `targetScrollOffset` isn't properly resetted.

This PR fixes that and also removes the unnecessary checks from #241.