### PR TITLE
[WIP][FEATURE] Passthrough Properties

### DIFF
--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -359,7 +359,7 @@ export default Component.extend({
 
   toggleExpandedRow(row) {
     let multi = this.get('multiRowExpansion');
-    let shouldExpand = !row.expanded;
+    let shouldExpand = !row.get('expanded');
 
     if (multi) {
       row.toggleProperty('expanded');
@@ -403,10 +403,8 @@ export default Component.extend({
           }
         }
         this._prevSelectedIndex = currIndex;
-      } else {
-        if (this.get('canExpand') && this.get('expandOnClick')) {
-          this.toggleExpandedRow(row);
-        }
+      } else if (this.get('canExpand') && this.get('expandOnClick')) {
+        this.toggleExpandedRow(row);
       }
 
       callAction(this, 'onRowClick', ...arguments);


### PR DESCRIPTION
Closes #151.

This is a stab at implementing properties for `Row`s that are optionally passed through to the `content` object.

The API is similar to the `classNameBindings` property of `Ember.Component` with the extra ability to invert properties.

For example:

```js
new Row(content, { passthrough: ['selected', 'expanded:isShowingMore', 'hidden:!visible'] });
```

Relevant docs from the PR:

```js
  /**
   * Properties listed here are passed through to the `content` object instead
   * of getting shadowed by the `ObjectProxy` behavior of `Row`.
   *
   * You can use mappings similar to `classNameBindings` in `Ember.Component`.
   *
   * - `'selected'` - transparently pass through the `selected` property
   * - `'expanded:isShowingMore'` - map the `expanded` property to the
   *   `isShowingMore` property
   * - `'hidden:!visible'` - map the `hidden` property to the `visible` property
   *   and invert the value
   *
   * @property passthrough
   * @type {Array}
   * @default []
   */
  passthrough: computed(() => []),
```

Do you like the way this implemented?

If you're okay with this, I'd make the required changes in `Table.js` to be able to actually configure a table to use passthrough properties and fix the tests.