### PR TITLE
Add failing test for Ember 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-2.3
   - EMBER_TRY_SCENARIO=ember-2.4
+  - EMBER_TRY_SCENARIO=ember-2.7
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -21,6 +21,13 @@ module.exports = {
       }
     }
   }, {
+    name: 'ember-2.7',
+    bower: {
+      dependencies: {
+        'ember': '2.7.3'
+      }
+    }
+  }, {
     name: 'ember-release',
     bower: {
       dependencies: {


### PR DESCRIPTION
I added this ember-try scenario to document that tests are actually failing for Ember 2.7 and probably also 2.6, since upgrading ember-wormhole to 0.5.1. Encountered this in one of our apps. Same things happens in ember-bootstrap when using the same wormhole version (see https://github.com/kaliber5/ember-bootstrap/pull/160).

Will file an issue with ember-wormhole...