### PR TITLE
[BUGFIX] Resolve IE drag and drop crashes

### DIFF
--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -44,7 +44,7 @@ export default Ember.Mixin.create({
     let column = this.get('column');
 
     e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', column.get('columnId'));
+    e.dataTransfer.setData('text', column.get('columnId'));
 
     sourceColumn = column;
     this.set('isDragging', true);

--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -43,8 +43,11 @@ export default Ember.Mixin.create({
 
     let column = this.get('column');
 
-    e.dataTransfer.effectAllowed = 'move';
+    /*
+      NOTE: IE requires setData type to be 'text'
+     */
     e.dataTransfer.setData('text', column.get('columnId'));
+    e.dataTransfer.effectAllowed = 'move';
 
     sourceColumn = column;
     this.set('isDragging', true);


### PR DESCRIPTION
Resolves #273.

@lonelyghost any chance of you testing out this branch for me? I was able to get it working on a BrowserStack trial account in IE11 with this fix but I'm not able to check older versions.  

Fix found @ [Stack Overflow](http://stackoverflow.com/questions/26213011/html5-dragdrop-issue-in-internet-explorer-datatransfer-property-access-not-pos)