### PR TITLE
[FEATURE] Add selectOnClick option

### DIFF
--- a/tests/dummy/app/templates/components/selectable-table.hbs
+++ b/tests/dummy/app/templates/components/selectable-table.hbs
@@ -1,11 +1,13 @@
 {{!-- BEGIN-SNIPPET selectable-table --}}
 {{#ember-wormhole to="table-actions"}}
-  {{#if hasSelection}}
-    <div class="table-action fa fa-check-square-o" title="Deselect all" {{action 'deselectAll'}}></div>
-    <div class="table-action fa fa-trash-o delete" title="Delete selected" {{action 'deleteAll'}}></div>
-  {{else}}
-    <div class="table-action fa fa-square-o" title="Select all" {{action 'selectAll'}}></div>
-  {{/if}}
+  <div>
+    {{#if hasSelection}}
+      <div class="table-action fa fa-check-square-o" title="Deselect all" {{action 'deselectAll'}}></div>
+      <div class="table-action fa fa-trash-o delete" title="Delete selected" {{action 'deleteAll'}}></div>
+    {{else}}
+      <div class="table-action fa fa-square-o" title="Select all" {{action 'selectAll'}}></div>
+    {{/if}}
+  </div>
 {{/ember-wormhole}}
 
 {{#light-table table height='65vh' as |t|}}


### PR DESCRIPTION
Resolves #289. 

Select a row on click. If this is set to `false` and multiSelect is enabled, using click + `shift`, `cmd`, or `ctrl` will still work as intended, while clicking on the row will not set the row as selected.

/cc @karellm. Can you please check out this branch and test it out in your app?