### PR TITLE
Calculate the total table width more precisely

### DIFF
--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -155,57 +155,39 @@ const LightTable = Component.extend({
   visibleColumns: computed.readOnly('table.visibleColumns'),
 
   /**
-   * Calculates the total width of the visible columns via their `width`
-   * propert.
+   * Calculates the total width of the visible column elements via their `width`
+   * property.
    *
    * Returns 0 for the following conditions
    *  - All widths are not set
    *  - Widths are not the same unit
-   *  - Unit cannot be determined
    *
    * @property totalWidth
    * @type {Number}
    * @private
    */
-  totalWidth: computed('visibleColumns.[]', 'visibleColumns.@each.width', function() {
-    let visibleColumns = this.get('visibleColumns');
-    let widths = visibleColumns.getEach('width');
-    let unit = (widths[0] || '').match(/\D+$/);
+  totalWidth: computed('columnElements.[]', function() {
+    let columnElements = this.get('columnElements');
     let totalWidth = 0;
 
-    if (isEmpty(unit)) {
-      return 0;
+    for (let el of columnElements) {
+      totalWidth += el.offsetWidth;
     }
-
-    unit = unit[0];
-
-    /*
-      1. Check if all widths are present
-      2. Check if all widths are the same unit
-     */
-    for (let i = 0; i < widths.length; i++) {
-      let width = widths[i];
-
-      if (isNone(width) || width.indexOf(unit) === -1) {
-        return 0;
-      }
-
-      totalWidth += parseInt(width, 10);
-    }
-
-    return `${totalWidth}${unit}`;
+    return totalWidth;
   }),
 
   style: computed('totalWidth', 'height', function() {
     let totalWidth = this.get('totalWidth');
     let style = this.getProperties(['height']);
 
-    if (totalWidth) {
-      style.width = totalWidth;
-      style.overflowX = 'auto';
-    }
+    style.width = `${totalWidth}px`;
+    style.overflowX = 'auto';
 
     return cssStyleify(style);
+  }),
+
+  columnElements: Ember.computed(function() {
+    return Ember.A();
   }),
 
   init() {
@@ -219,6 +201,11 @@ const LightTable = Component.extend({
     if (isNone(media)) {
       this.set('responsive', false);
     }
+
+    // wait until after view's element has rendered in order to query the column elements
+    Ember.run.scheduleOnce('afterRender', () => {
+      this.set('columnElements', this.get('element').querySelectorAll('.lt-head tr:first-child th'));
+    });
   },
 
   onMediaChange: on('init', observer('media.matches.[]', 'table.allColumns.[]', function() {


### PR DESCRIPTION
The `totalWidth` of the table is calculated by the table headers, however its result calculation does not take in account when these table headers have padding and borders.

This changes the code to calculate the total width of the table based on the `<th>` elements vs. strings in columns, allowing use to use the `offsetWidth` property that includes the element's padding and border in its width output.