### PR TITLE
Change <span> to <i> tag for sorting icons

### DIFF
--- a/addon/templates/components/columns/base.hbs
+++ b/addon/templates/components/columns/base.hbs
@@ -3,7 +3,7 @@
 {{else}}
   {{label}}
   {{#if column.sorted}}
-    <span class="lt-sort-icon {{if column.ascending sortIcons.iconAscending sortIcons.iconDescending}}"></span>
+    <i class="lt-sort-icon {{if column.ascending sortIcons.iconAscending sortIcons.iconDescending}}"></i>
   {{/if}}
 {{/if}}
 


### PR DESCRIPTION
Updated the `<span>` tag to an `<i>` tag in order to allow Semantic UI icons to appear. Font Awesome icons work in either and `<i>` tag or a <span> tag but Semantic UI icons only show up if they are wrapped in an `<i>` tag.