### PR TITLE
Move ember-cli-string-helpers to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "ember-cli-qunit": "^3.0.2",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-string-helpers": "1.0.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-yuidoc": "0.8.8",
@@ -67,6 +66,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.11",
+    "ember-cli-string-helpers": "1.0.0",
     "ember-composable-helpers": "^2.0.1",
     "ember-get-config": "0.2.1",
     "ember-in-viewport": "2.1.1",


### PR DESCRIPTION
The `{{html-safe}}` helper [here](https://github.com/offirgolan/ember-light-table/blob/master/addon/templates/components/lt-foot.hbs#L7
) is the cause for the PR. The string helpers in `ember-composable-helpers` [were moved](https://github.com/DockYard/ember-composable-helpers/pull/237) to `ember-cli-string-helpers`, which is why that add-on is a `devDependency` of `ember-light-table`.

I have an Ember add-on which houses a paginated table component built using ELT. `ember-light-table` is listed as a dependency of that add-on. Installing that add-on in my engines and consuming app results in the following error: `Compile Error: html-safe is not a helper`. 

My fork has fixed this issue for me 🙃 