### PR TITLE
Update ember-truth-helpers dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ember-resolver": "^2.0.3",
     "ember-responsive": "2.0.2",
     "ember-suave": "4.0.1",
-    "ember-truth-helpers": "1.3.0",
     "loader.js": "^4.0.10",
     "yuidoc-ember-theme": "^1.2.1"
   },
@@ -71,7 +70,7 @@
     "ember-get-config": "0.2.1",
     "ember-in-viewport": "2.1.1",
     "ember-scrollable": "^0.4.4",
-    "ember-truth-helpers": "1.2.0",
+    "ember-truth-helpers": "1.3.0",
     "ember-wormhole": "^0.5.1"
   },
   "ember-addon": {


### PR DESCRIPTION
It was defined in both dev and regular dependencies, but with two different versions.