### PR TITLE
Fix broken onScroll handler after v1.8.6

### DIFF
--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -9,7 +9,7 @@
     virtualScrollbar=useVirtualScrollbar
     autoHide=autoHideScrollbar
     scrollTo=targetScrollOffset
-    onScrollToY=(action 'onScroll')
+    onScrollY=(action 'onScroll')
   }}
     <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>
 

--- a/addon/templates/components/lt-scrollable.hbs
+++ b/addon/templates/components/lt-scrollable.hbs
@@ -5,7 +5,7 @@
     horizontal=horizontal
     vertical=vertical
     scrollToY=scrollTo
-    onScrollToY=onScrollToY
+    onScrollY=onScrollY
     as |scrollbar|
   }}
     {{yield}}

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -189,3 +189,29 @@ test('passed in components can have computed properties', function(assert) {
 
   assert.equal(this.$('.custom-row.is-active').length, 0, 'none of the items are active');
 });
+
+test('onScroll', function(assert) {
+  let done = assert.async();
+  let table = new Table(Columns, createUsers(10));
+
+  this.setProperties({
+    table,
+    currentScrollY: 0,
+    onScroll() {
+      assert.ok(true, 'onScroll worked');
+      done();
+    }
+  });
+
+  this.render(hbs `
+    {{#light-table table height='40vh' as |t|}}
+      {{t.head fixed=true}}
+      {{t.body
+        useVirtualScrollbar=true
+        onScroll=onScroll
+      }}
+    {{/light-table}}
+  `);
+
+  this.$('.tse-scroll-content').scrollTop(300).scroll();
+});

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -193,12 +193,13 @@ test('passed in components can have computed properties', function(assert) {
 test('onScroll', function(assert) {
   let done = assert.async();
   let table = new Table(Columns, createUsers(10));
+  let expectedScroll = 50;
 
   this.setProperties({
     table,
-    currentScrollY: 0,
-    onScroll() {
+    onScroll(actualScroll) {
       assert.ok(true, 'onScroll worked');
+      assert.equal(actualScroll, expectedScroll, 'scroll position is correct');
       done();
     }
   });
@@ -213,5 +214,5 @@ test('onScroll', function(assert) {
     {{/light-table}}
   `);
 
-  this.$('.tse-scroll-content').scrollTop(300).scroll();
+  this.$('.tse-scroll-content').scrollTop(expectedScroll).scroll();
 });


### PR DESCRIPTION
After fixing deprecation message for onScroll, a typo was introduced by using `onScrollToY` instead of `onScrollY`. This PR resolves this problem by using the correct event handler and adds a basic test to ensure the event gets fired properly.