### PR TITLE
Resolves a bug caused by dragging columns/text onto other light tables

### DIFF
--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -41,6 +41,8 @@ export default Ember.Mixin.create({
 
   isDropTarget: computed(function() {
     let column = this.get('column');
+
+    if (!column || !sourceColumn) { return false; }
     /*
       A column is a valid drop target only if its in the same group
      */
@@ -52,6 +54,7 @@ export default Ember.Mixin.create({
 
     let column = this.get('column');
 
+    if (!column) { return; }
     /*
       NOTE: IE requires setData type to be 'text'
      */


### PR DESCRIPTION
I ran into this error when working with a list of separate ember-light-tables. Highlighting text and dragging it and the column onto another light table throws a `TypeError: Cannot read property 'get' of undefined`. 

My best guess is the event is being handled by a table that doesn't know about the column being dragged. It potentially skips the dragStart function. The column and/or source column are undefined in this case. 