### PR TITLE
Ensure the drop target remains properly identified for draggable columns

### DIFF
--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -84,6 +84,14 @@ export default Ember.Mixin.create({
 
     if (this.get('isDropTarget')) {
       e.preventDefault();
+      /*
+        NOTE: dragLeave will be triggered by any child elements inside the
+        column. This code ensures the column being dragged over continues to be
+        identified as the current drop target
+       */
+      if (!this.get('isDragTarget')) {
+        this.set('isDragTarget', this.get('column') !== sourceColumn);
+      }
     }
   },
 


### PR DESCRIPTION
closes #417 

[Special classes](http://offirgolan.github.io/ember-light-table/docs/classes/Column.html#property_draggable) are added to the cells that are being dragged over, so that they can be styled appropriately. However, `dragLeave` is not just triggered when the drag exits the cell, but also when the drag enters a child element inside the cell.

If the table is implemented with draggable columns, and also with either child elements inside the table header cells, or resizable columns, the `is-drag-target` class will be removed from the cell even while it is being dragged over. Resizable columns add a extra div (with class `lt-column-resizer`) inside the table header cell. This means that with both draggable and resizable columns, the drag target styling will rarely be applied when dragging to the left, while it mostly works while dragging to the right.

![inconsistent_drag_target](https://cloud.githubusercontent.com/assets/5260472/26704707/4fae8658-46ee-11e7-90f8-8b1a68c6ecc3.gif)

Here is an Ember-twiddle demonstrating the problem: https://ember-twiddle.com/4ab83dd0909fe3bc2083a47c1b0ba6fb?openFiles=components.expandable-table.js%2C

There are a few different ways to approach this problem but there are annoying edge cases that introduce new bugs for a few of them that I tried. This solution is to reset `isDragTarget` to true in `dragOver`, since it is constantly being called while the cell is being dragged over. It seems to work pretty well.

![consistent_drag_target](https://cloud.githubusercontent.com/assets/5260472/26704828/01167860-46ef-11e7-936a-56437de70dc9.gif)
Here is a Twiddle demonstrating this solution: https://ember-twiddle.com/e30d04f1e3e1f4cdb3f95749dbeb3f6c?openFiles=components.expandable-table.js%2C
