### PR TITLE
Polyfill support for __proto__ in IE <= 10

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import fixProto from 'ember-light-table/utils/fix-proto';
 
 const {
   guidFor,
@@ -344,3 +345,6 @@ export default class Column extends EmberObject.extend({
     this.set('subColumns', subColumns);
   }
 }
+
+// https://github.com/offirgolan/ember-light-table/issues/436#issuecomment-310138868
+fixProto(Column);

--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import fixProto from 'ember-light-table/utils/fix-proto';
 
 const {
   computed,
@@ -100,3 +101,6 @@ export default class Row extends ObjectProxy.extend({
     this.set('content', content);
   }
 }
+
+// https://github.com/offirgolan/ember-light-table/issues/436#issuecomment-310138868
+fixProto(Row);

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -3,6 +3,7 @@ import Row from 'ember-light-table/classes/Row';
 import Column from 'ember-light-table/classes/Column';
 import SyncArrayProxy from 'ember-light-table/-private/sync-array-proxy';
 import { mergeOptionsWithGlobals } from 'ember-light-table/-private/global-options';
+import fixProto from 'ember-light-table/utils/fix-proto';
 
 const {
   get,
@@ -425,3 +426,6 @@ export default class Table extends EmberObject.extend({
     return columns.map((c) => Table.createColumn(c));
   }
 }
+
+// https://github.com/offirgolan/ember-light-table/issues/436#issuecomment-310138868
+fixProto(Table);

--- a/addon/utils/fix-proto.js
+++ b/addon/utils/fix-proto.js
@@ -1,0 +1,76 @@
+/**
+ * @module Utils
+ * @private
+ */
+
+/**
+ * Internet Explorer <= 10 has no support for `__proto__`.
+ * This conditional polyfill works around that, so that static methods like
+ * `reopen` may be used. There are some caveats though.
+ *
+ * For more information, please see: [Issue #436 (comment)][436]
+ *
+ * [436]: https://github.com/offirgolan/ember-light-table/issues/436#issuecomment-310138868
+ *
+ * @class fixProto
+ */
+
+/**
+ * Whether or not this environment supports `__proto__`.
+ * IE <= 10 is known to not support it-
+ *
+ * More information on `__proto__`:
+ *
+ *   https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
+ *
+ * @const isProtoSupported
+ * @type {Boolean}
+ * @readOnly
+ */
+export const isProtoSupported = ({ __proto__: [] }) instanceof Array;
+
+/**
+ * Assigns all properties of `defaults` to `obj`, if they are not already
+ * defined on `obj`. This means that `obj` is mutated in place.
+ *
+ * Taken from:
+ *
+ *   https://github.com/babel/babel/blob/64eafad472ebac6333671fff65a9669739e6cd88/packages/babel-helpers/src/helpers.js#L287-L299
+ *
+ * @method defaults
+ * @param  {Object} obj      The object to assign the default properties to
+ * @param  {Object} defaults The object that provides all default properties to
+ *                           be assigned
+ * @return {Object}          The `obj` that was passed in
+ */
+export function defaults(obj, defaults) {
+  const keys = Object.getOwnPropertyNames(defaults);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = Object.getOwnPropertyDescriptor(defaults, key);
+    if (value && value.configurable && obj[key] === undefined) {
+      Object.defineProperty(obj, key, value);
+    }
+  }
+  return obj;
+}
+
+/**
+ * Conditionally attempt to polyfill support for `__proto__` in environments
+ * that do not support it.
+ *
+ * If `__proto__` is not supported, this function assigns all properties and
+ * methods pf `Class.__proto__` to `Class` itself.
+ *
+ * @method fixProto
+ * @param  {Function} Class The base class
+ * @return {Function}       The `Class` that was passed in
+ */
+export default function fixProto(Class) {
+  if (isProtoSupported) {
+    return;
+  }
+
+  // https://github.com/babel/babel/tree/64eafad472ebac6333671fff65a9669739e6cd88/packages/babel-plugin-transform-proto-to-assign#example
+  return defaults(Class, Class.__proto__);
+}

--- a/tests/unit/classes/column-test.js
+++ b/tests/unit/classes/column-test.js
@@ -29,6 +29,11 @@ test('create column - column instance', function(assert) {
   assert.equal(col2.label, 'Name');
 });
 
+test('reopen colum', function(assert) {
+  assert.equal(typeof Column.reopen, 'function', 'reopen is a function');
+  assert.equal(typeof Column.reopenClass, 'function', 'reopenClass is a function');
+});
+
 test('CP - isGroupColumn', function(assert) {
   let col = new Column();
   assert.ok(col);

--- a/tests/unit/classes/row-test.js
+++ b/tests/unit/classes/row-test.js
@@ -19,3 +19,8 @@ test('create row - row instance', function(assert) {
   assert.equal(row.get('foo'), 'bar');
   assert.equal(row2.get('foo'), 'bar');
 });
+
+test('reopen row', function(assert) {
+  assert.equal(typeof Row.reopen, 'function', 'reopen is a function');
+  assert.equal(typeof Row.reopenClass, 'function', 'reopenClass is a function');
+});

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -27,6 +27,11 @@ test('create table - with options', function(assert) {
   assert.ok(table.columns[0] instanceof Column);
 });
 
+test('reopen table', function(assert) {
+  assert.equal(typeof Table.reopen, 'function', 'reopen is a function');
+  assert.equal(typeof Table.reopenClass, 'function', 'reopenClass is a function');
+});
+
 test('CP - visibleColumnGroups', function(assert) {
   let table = new Table();
   let col = new Column();

--- a/tests/unit/utils/fix-proto-test.js
+++ b/tests/unit/utils/fix-proto-test.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+import fixProto from 'ember-light-table/utils/fix-proto';
+import { module, test } from 'qunit';
+
+const {
+  Object: EmberObject
+} = Ember;
+
+module('Unit | Utility | fix proto');
+
+/*
+ * Running this test in an environment that does not need the polyfill doesn't
+ * make any sense. The only relevent environments are IE <= 10.
+ */
+
+test('ES6 classes that extend `Ember.Object` can be reopened after `fixProto` was used on them', function(assert) {
+  class DerivedClass extends EmberObject.extend() {}
+
+  fixProto(DerivedClass);
+
+  DerivedClass.reopenClass({
+    someStaticMethod() {
+      return true;
+    }
+  });
+  assert.ok(DerivedClass.someStaticMethod(), 'reopenClass works');
+
+  DerivedClass.reopen({
+    someMethod() {
+      return true;
+    }
+  });
+  let instance = new DerivedClass();
+  assert.ok(instance.someMethod(), 'reopen works');
+});


### PR DESCRIPTION
Fixes #436.

This gives full support for stuff like this in IE <= 10:

```js
Table.reopen({
  getFirstColumn() {
    return this.get('columns.firstObject');
  }
});
```

---

### Juicy technical details

[MDN on `Object.prototype.__proto__`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)

> ### [Internet Explorer](https://babeljs.io/docs/usage/caveats/#internet-explorer-classes-10-and-below-)
> #### Classes (10 and below)
> If you’re inheriting from a class then static properties are inherited from it via `__proto__`, this is widely supported but you may run into problems with much older browsers.
>
> **NOTE:** `__proto__` is not supported on IE <= 10 so static properties will not be inherited. See the [protoToAssign](https://babeljs.io/docs/plugins/transform-proto-to-assign/) for a possible work around.

> # [babel-plugin-transform-proto-to-assign](https://github.com/babel/babel/tree/64eafad472ebac6333671fff65a9669739e6cd88/packages/babel-plugin-transform-proto-to-assign)
>
> > This plugin allows Babel to transform all `__proto__` assignments to a method that will do a shallow copy of all properties.
>
> ## Detail
>
> This means that the following **will** work:
>
> ```javascript
> var foo = { a: 1 };
> var bar = { b: 2 };
> bar.__proto__ = foo;
> bar.a; // 1
> bar.b; // 2
> ```
>
> however the following **will not**:
>
> ```javascript
> var foo = { a: 1 };
> var bar = { b: 2 };
> bar.__proto__ = foo;
> bar.a; // 1
> foo.a = 2;
> bar.a; // 1 - should be 2 but remember that nothing is bound and it's a straight copy
> ```
>
> This is a case that you have to be aware of if you intend to use this plugin.