### PR TITLE
[chore]: Testing cleanup -- ember-native-dom-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",
     "ember-load-initializers": "^1.0.0",
+    "ember-native-dom-helpers": "^0.5.0",
     "ember-one-way-controls": "2.0.0",
     "ember-owner-test-utils": "^0.1.2",
     "ember-resolver": "^4.0.0",

--- a/tests/helpers/create-click-event.js
+++ b/tests/helpers/create-click-event.js
@@ -1,5 +1,0 @@
-export default function createClickEvent(opts = {}) {
-  let e = new $.Event('click');
-  Object.keys(opts).forEach((o) => e[o] = opts[o]);
-  return e;
-}

--- a/tests/helpers/has-class.js
+++ b/tests/helpers/has-class.js
@@ -1,0 +1,4 @@
+
+export default function hasClass(elem, cls) {
+  return [...elem.classList].filter((cssClass) => cssClass === cls).reduce((bool, next) => bool || next, false);
+}

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -1,9 +1,11 @@
+import { findAll, find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import { skip } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import startMirage, { createUsers } from '../../helpers/setup-mirage-for-integration';
 import Table from 'ember-light-table';
 import Columns from '../../helpers/table-columns';
+import hasClass from '../../helpers/has-class';
 import RowComponent from 'ember-light-table/components/lt-row';
 import { register } from 'ember-owner-test-utils/test-support/register';
 import Ember from 'ember';
@@ -19,7 +21,7 @@ test('it renders', function(assert) {
   this.set('table', new Table());
   this.render(hbs `{{light-table table}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 });
 
 // TODO: Figure out why tests is failing in Phantom.js
@@ -41,12 +43,12 @@ skip('scrolled to bottom', function(assert) {
     {{/light-table}}
   `);
 
-  assert.equal(this.$('tbody > tr').length, 50, '50 rows are rendered');
+  assert.equal(findAll('tbody > tr').length, 50, '50 rows are rendered');
 
   let scrollContainer = '.tse-scroll-content';
-  let scrollHeight = this.$(scrollContainer).prop('scrollHeight');
+  let { scrollHeight } = find(scrollContainer);
 
-  assert.ok(this.$(scrollContainer).length > 0, 'scroll container was rendered');
+  assert.ok(findAll(scrollContainer).length > 0, 'scroll container was rendered');
   assert.equal(scrollHeight, 2500, 'scroll height is 2500');
 
   this.$(scrollContainer).animate({
@@ -67,11 +69,11 @@ test('fixed header', function(assert) {
     {{/light-table}}
   `);
 
-  assert.equal(this.$('#lightTable_inline_head thead').length, 0);
+  assert.equal(findAll('#lightTable_inline_head thead').length, 0);
 
   this.set('fixed', false);
 
-  assert.equal(this.$('#lightTable_inline_head thead').length, 1);
+  assert.equal(findAll('#lightTable_inline_head thead').length, 1);
 });
 
 test('fixed footer', function(assert) {
@@ -86,11 +88,11 @@ test('fixed footer', function(assert) {
     {{/light-table}}
   `);
 
-  assert.equal(this.$('#lightTable_inline_foot tfoot').length, 0);
+  assert.equal(findAll('#lightTable_inline_foot tfoot').length, 0);
 
   this.set('fixed', false);
 
-  assert.equal(this.$('#lightTable_inline_foot tfoot').length, 1);
+  assert.equal(findAll('#lightTable_inline_foot tfoot').length, 1);
 });
 
 // TODO: Passes in Chrome but not in Phantom
@@ -150,7 +152,7 @@ test('accepts components that are used in the body', function(assert) {
     {{/light-table}}
   `);
 
-  assert.equal(this.$('.lt-row.custom-row').length, 1, 'row has custom-row class');
+  assert.equal(findAll('.lt-row.custom-row').length, 1, 'row has custom-row class');
 });
 
 test('passed in components can have computed properties', function(assert) {
@@ -174,20 +176,20 @@ test('passed in components can have computed properties', function(assert) {
     {{/light-table}}
   `);
 
-  assert.equal(this.$('.custom-row').length, 3, 'three custom rows were rendered');
-  assert.equal(this.$('.custom-row.is-active').length, 0, 'none of the items are active');
+  assert.equal(findAll('.custom-row').length, 3, 'three custom rows were rendered');
+  assert.notOk(find('.custom-row.is-active'), 'none of the items are active');
 
   this.set('current', users[0]);
-
-  assert.ok(this.$('.custom-row:eq(0)').hasClass('is-active'), 'first custom row is active');
+  let [firstRow] = findAll('.custom-row');
+  assert.ok(hasClass(firstRow, 'is-active'), 'first custom row is active');
 
   this.set('current', users[2]);
-
-  assert.ok(this.$('.custom-row:eq(2)').hasClass('is-active'), 'third custom row is active');
+  let [,, thirdRow] = findAll('.custom-row');
+  assert.ok(hasClass(thirdRow, 'is-active'), 'third custom row is active');
 
   this.set('current', null);
 
-  assert.equal(this.$('.custom-row.is-active').length, 0, 'none of the items are active');
+  assert.notOk(find('.custom-row.is-active'), 'none of the items are active');
 });
 
 test('onScroll', function(assert) {

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -1,4 +1,4 @@
-import { findAll, find } from 'ember-native-dom-helpers';
+import { findAll, find, scrollTo } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import { skip } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
@@ -25,15 +25,13 @@ test('it renders', function(assert) {
 });
 
 // TODO: Figure out why tests is failing in Phantom.js
-skip('scrolled to bottom', function(assert) {
+skip('scrolled to bottom', async function(assert) {
   assert.expect(4);
-  let done = assert.async();
 
   this.set('table', new Table(Columns, createUsers(50)));
 
   this.on('onScrolledToBottom', () => {
     assert.ok(true);
-    done();
   });
 
   this.render(hbs `
@@ -51,10 +49,7 @@ skip('scrolled to bottom', function(assert) {
   assert.ok(findAll(scrollContainer).length > 0, 'scroll container was rendered');
   assert.equal(scrollHeight, 2500, 'scroll height is 2500');
 
-  this.$(scrollContainer).animate({
-    scrollTop: scrollHeight
-  }, 0);
-
+  await scrollTo(scrollContainer, 0, scrollHeight);
 });
 
 test('fixed header', function(assert) {
@@ -111,7 +106,7 @@ skip('table assumes height of container', function(assert) {
     </div>
   `);
 
-  assert.equal(this.$('#lightTable').height(), 500, 'table is 500px height');
+  assert.equal(find('#lightTable').offsetHeight, 500, 'table is 500px height');
 
 });
 
@@ -133,10 +128,9 @@ skip('table body should consume all available space when not enough content to f
       {{/light-table}}
     </div>
   `);
-
-  assert.equal(this.$('.lt-head-wrap').height(), 42, 'header is 42px tall');
-  assert.equal(this.$('.lt-body-wrap').height(), 438, 'body is 438px tall');
-  assert.equal(this.$('.lt-foot-wrap').height(), 20, 'header is 20px tall');
+  assert.equal(find('.lt-head-wrap').offsetHeight, 42, 'header is 42px tall');
+  assert.equal(find('.lt-body-wrap').offsetHeight, 438, 'body is 438px tall');
+  assert.equal(find('.lt-foot-wrap').offsetHeight, 20, 'header is 20px tall');
 
 });
 
@@ -192,8 +186,7 @@ test('passed in components can have computed properties', function(assert) {
   assert.notOk(find('.custom-row.is-active'), 'none of the items are active');
 });
 
-test('onScroll', function(assert) {
-  let done = assert.async();
+test('onScroll', async function(assert) {
   let table = new Table(Columns, createUsers(10));
   let expectedScroll = 50;
 
@@ -202,7 +195,6 @@ test('onScroll', function(assert) {
     onScroll(actualScroll) {
       assert.ok(true, 'onScroll worked');
       assert.equal(actualScroll, expectedScroll, 'scroll position is correct');
-      done();
     }
   });
 
@@ -216,5 +208,5 @@ test('onScroll', function(assert) {
     {{/light-table}}
   `);
 
-  this.$('.tse-scroll-content').scrollTop(expectedScroll).scroll();
+  await scrollTo('.tse-scroll-content', 0, expectedScroll);
 });

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -178,7 +178,7 @@ test('passed in components can have computed properties', function(assert) {
   assert.ok(hasClass(firstRow, 'is-active'), 'first custom row is active');
 
   this.set('current', users[2]);
-  let [,, thirdRow] = findAll('.custom-row');
+  let thirdRow = find('.custom-row:nth-child(3)');
   assert.ok(hasClass(thirdRow, 'is-active'), 'third custom row is active');
 
   this.set('current', null);

--- a/tests/integration/components/light-table/cells/base-test.js
+++ b/tests/integration/components/light-table/cells/base-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
@@ -11,7 +12,7 @@ test('it renders', function(assert) {
   this.set('column', new Column());
   this.render(hbs`{{light-table/cells/base column=column}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 });
 
 test('cell with column format', function(assert) {
@@ -26,7 +27,7 @@ test('cell with column format', function(assert) {
 
   this.render(hbs`{{light-table/cells/base column row rawValue=2}}`);
 
-  assert.equal(this.$().text().trim(), '4');
+  assert.equal(find('*').textContent.trim(), '4');
 });
 
 test('cell format with no valuePath', function(assert) {
@@ -42,7 +43,7 @@ test('cell format with no valuePath', function(assert) {
 
   this.render(hbs`{{light-table/cells/base column row}}`);
 
-  assert.equal(this.$().text().trim(), '4');
+  assert.equal(find('*').textContent.trim(), '4');
 });
 
 test('cell with nested valuePath', function(assert) {
@@ -63,9 +64,9 @@ test('cell with nested valuePath', function(assert) {
 
   this.render(hbs`{{light-table/cells/base column row rawValue=(get row column.valuePath)}}`);
 
-  assert.equal(this.$().text().trim(), '4');
+  assert.equal(find('*').textContent.trim(), '4');
 
   Ember.run(() => this.get('row').set(this.get('column.valuePath'), 4));
 
-  assert.equal(this.$().text().trim(), '8');
+  assert.equal(find('*').textContent.trim(), '8');
 });

--- a/tests/integration/components/light-table/columns/base-test.js
+++ b/tests/integration/components/light-table/columns/base-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { Column } from 'ember-light-table';
@@ -11,5 +12,5 @@ test('it renders', function(assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });"
   this.set('column', new Column());
   this.render(hbs`{{light-table/columns/base column=column}}`);
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 });

--- a/tests/integration/components/lt-body-test.js
+++ b/tests/integration/components/lt-body-test.js
@@ -34,7 +34,7 @@ test('row selection - enable or disable', function(assert) {
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect}}`);
 
-  let [row] = findAll('tr');
+  let row = find('tr');
 
   assert.notOk(hasClass(row, 'is-selectable'));
   assert.notOk(hasClass(row, 'is-selected'));
@@ -53,9 +53,9 @@ test('row selection - ctrl-click to modify selection', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true}}`);
-  let rows = findAll('tr');
-  let [firstRow, , , middleRow] = rows;
-  let lastRow = rows[rows.length - 1];
+  let firstRow = find('tr:first-child');
+  let middleRow = find('tr:nth-child(4)');
+  let lastRow = find('tr:last-child');
 
   assert.equal(findAll('tbody > tr').length, 5);
 
@@ -77,9 +77,9 @@ test('row selection - click to modify selection', function(assert) {
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true multiSelectRequiresKeyboard=false}}`);
 
-  let rows = findAll('tr');
-  let [firstRow, , , middleRow] = rows;
-  let lastRow = rows[rows.length - 1];
+  let firstRow = find('tr:first-child');
+  let middleRow = find('tr:nth-child(4)');
+  let lastRow = find('tr:last-child');
 
   assert.equal(findAll('tbody > tr').length, 5);
 
@@ -106,7 +106,7 @@ test('row expansion', function(assert) {
     {{/lt-body}}
   `);
 
-  let [row] = findAll('tr');
+  let row = find('tr');
 
   assert.notOk(hasClass(row, 'is-expandable'));
   click(row);
@@ -159,7 +159,7 @@ test('row actions', function(assert) {
   this.on('onRowDoubleClick', (row) => assert.ok(row));
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions onRowClick=(action 'onRowClick') onRowDoubleClick=(action 'onRowDoubleClick')}}`);
 
-  let [row] = findAll('tr');
+  let row = find('tr');
   click(row);
   triggerEvent(row, 'dblclick');
 });

--- a/tests/integration/components/lt-body-test.js
+++ b/tests/integration/components/lt-body-test.js
@@ -1,9 +1,10 @@
+import { click, findAll, find, triggerEvent } from 'ember-native-dom-helpers';
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import startMirage, { createUsers } from '../../helpers/setup-mirage-for-integration';
 import Table from 'ember-light-table';
-import createClickEvent from '../../helpers/create-click-event';
+import hasClass from '../../helpers/has-class';
 import Columns from '../../helpers/table-columns';
 
 const {
@@ -24,7 +25,7 @@ moduleForComponent('lt-body', 'Integration | Component | lt body', {
 
 test('it renders', function(assert) {
   this.render(hbs `{{lt-body sharedOptions=sharedOptions}}`);
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 });
 
 test('row selection - enable or disable', function(assert) {
@@ -33,47 +34,42 @@ test('row selection - enable or disable', function(assert) {
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect}}`);
 
-  let row = this.$('tr:first');
+  let [row] = findAll('tr');
 
-  assert.ok(!row.hasClass('is-selectable'));
-  assert.ok(!row.hasClass('is-selected'));
-  row.click();
-  assert.ok(!row.hasClass('is-selected'));
+  assert.notOk(hasClass(row, 'is-selectable'));
+  assert.notOk(hasClass(row, 'is-selected'));
+  click(row);
+  assert.notOk(hasClass(row, 'is-selected'));
 
   this.set('canSelect', true);
 
-  assert.ok(row.hasClass('is-selectable'));
-  assert.ok(!row.hasClass('is-selected'));
-  row.click();
-  assert.ok(row.hasClass('is-selected'));
+  assert.ok(hasClass(row, 'is-selectable'));
+  assert.notOk(hasClass(row, 'is-selected'));
+  click(row);
+  assert.ok(hasClass(row, 'is-selected'));
 });
 
 test('row selection - ctrl-click to modify selection', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true}}`);
+  let rows = findAll('tr');
+  let [firstRow, , , middleRow] = rows;
+  let lastRow = rows[rows.length - 1];
 
-  let firstRow = this.$('tr:first');
-  let middleRow = this.$('tr:nth-of-type(3)');
-  let lastRow = this.$('tr:last');
+  assert.equal(findAll('tbody > tr').length, 5);
 
-  assert.equal(this.$('tbody > tr').length, 5);
+  click(firstRow);
+  assert.equal(findAll('tr.is-selected').length, 1, 'clicking a row selects it');
 
-  firstRow.click();
-  assert.equal(this.$('tr.is-selected').length, 1, 'clicking a row selects it');
+  click(lastRow, { shiftKey: true });
+  assert.equal(findAll('tr.is-selected').length, 5, 'shift-clicking another row selects it and all rows between');
 
-  lastRow.trigger(createClickEvent({
-    shiftKey: true
-  }));
-  assert.equal(this.$('tr.is-selected').length, 5, 'shift-clicking another row selects it and all rows between');
+  click(middleRow, { ctrlKey: true });
+  assert.equal(findAll('tr.is-selected').length, 4, 'ctrl-clicking a selected row deselects it');
 
-  middleRow.trigger(createClickEvent({
-    ctrlKey: true
-  }));
-  assert.equal(this.$('tr.is-selected').length, 4, 'ctrl-clicking a selected row deselects it');
-
-  firstRow.click();
-  assert.equal(this.$('tr.is-selected').length, 0, 'clicking a selected row deselects all rows');
+  click(firstRow);
+  assert.equal(findAll('tr.is-selected').length, 0, 'clicking a selected row deselects all rows');
 });
 
 test('row selection - click to modify selection', function(assert) {
@@ -81,25 +77,23 @@ test('row selection - click to modify selection', function(assert) {
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true multiSelectRequiresKeyboard=false}}`);
 
-  let firstRow = this.$('tr:first');
-  let middleRow = this.$('tr:nth-of-type(3)');
-  let lastRow = this.$('tr:last');
+  let rows = findAll('tr');
+  let [firstRow, , , middleRow] = rows;
+  let lastRow = rows[rows.length - 1];
 
-  assert.equal(this.$('tbody > tr').length, 5);
+  assert.equal(findAll('tbody > tr').length, 5);
 
-  firstRow.click();
-  assert.equal(this.$('tr.is-selected').length, 1, 'clicking a row selects it');
+  click(firstRow);
+  assert.equal(findAll('tr.is-selected').length, 1, 'clicking a row selects it');
 
-  lastRow.trigger(createClickEvent({
-    shiftKey: true
-  }));
-  assert.equal(this.$('tr.is-selected').length, 5, 'shift-clicking another row selects it and all rows between');
+  click(lastRow, { shiftKey: true });
+  assert.equal(findAll('tr.is-selected').length, 5, 'shift-clicking another row selects it and all rows between');
 
-  middleRow.click();
-  assert.equal(this.$('tr.is-selected').length, 4, 'clicking a selected row deselects it without affecting other selected rows');
+  click(middleRow);
+  assert.equal(findAll('tr.is-selected').length, 4, 'clicking a selected row deselects it without affecting other selected rows');
 
-  middleRow.click();
-  assert.equal(this.$('tr.is-selected').length, 5, 'clicking a deselected row selects it without affecting other selected rows');
+  click(middleRow);
+  assert.equal(findAll('tr.is-selected').length, 5, 'clicking a deselected row selects it without affecting other selected rows');
 });
 
 test('row expansion', function(assert) {
@@ -112,28 +106,29 @@ test('row expansion', function(assert) {
     {{/lt-body}}
   `);
 
-  let row = this.$('tr:first');
+  let [row] = findAll('tr');
 
-  assert.ok(!row.hasClass('is-expandable'));
-  row.click();
-  assert.equal(this.$('tr.lt-expanded-row').length, 0);
-  assert.equal(this.$('tbody > tr').length, 2);
-  assert.equal(this.$('tr.lt-expanded-row').text().trim(), '');
+  assert.notOk(hasClass(row, 'is-expandable'));
+  click(row);
+  assert.equal(findAll('tr.lt-expanded-row').length, 0);
+  assert.equal(findAll('tbody > tr').length, 2);
+  assert.notOk(find('tr.lt-expanded-row'));
 
   this.set('canExpand', true);
 
-  assert.ok(row.hasClass('is-expandable'));
-  row.click();
-  assert.equal(this.$('tr.lt-expanded-row').length, 1);
-  assert.equal(this.$('tbody > tr').length, 3);
-  assert.equal(row.next().text().trim(), 'Hello');
+  assert.ok(hasClass(row, 'is-expandable'));
+  click(row);
+  assert.equal(findAll('tr.lt-expanded-row').length, 1);
+  assert.equal(findAll('tbody > tr').length, 3);
+  assert.equal(row.nextElementSibling.textContent.trim(), 'Hello');
 
-  row = this.$('tr:last');
-  assert.ok(row.hasClass('is-expandable'));
-  row.click();
-  assert.equal(this.$('tr.lt-expanded-row').length, 1);
-  assert.equal(this.$('tbody > tr').length, 3);
-  assert.equal(row.next().text().trim(), 'Hello');
+  let allRows = findAll('tr');
+  row = allRows[allRows.length - 1];
+  assert.ok(hasClass(row, 'is-expandable'));
+  click(row);
+  assert.equal(findAll('tr.lt-expanded-row').length, 1);
+  assert.equal(findAll('tbody > tr').length, 3);
+  assert.equal(row.nextElementSibling.textContent.trim(), 'Hello');
 });
 
 test('row expansion - multiple', function(assert) {
@@ -144,17 +139,16 @@ test('row expansion - multiple', function(assert) {
     {{/lt-body}}
   `);
 
-  let rows = this.$('tr');
+  let rows = findAll('tr');
   assert.equal(rows.length, 2);
 
-  rows.each((i, r) => {
-    let row = $(r);
-    assert.ok(row.hasClass('is-expandable'));
-    row.click();
-    assert.equal(row.next().text().trim(), 'Hello');
+  rows.forEach((row) => {
+    assert.ok(hasClass(row, 'is-expandable'));
+    click(row);
+    assert.equal(row.nextElementSibling.textContent.trim(), 'Hello');
   });
 
-  assert.equal(this.$('tr.lt-expanded-row').length, 2);
+  assert.equal(findAll('tr.lt-expanded-row').length, 2);
 });
 
 test('row actions', function(assert) {
@@ -165,9 +159,9 @@ test('row actions', function(assert) {
   this.on('onRowDoubleClick', (row) => assert.ok(row));
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions onRowClick=(action 'onRowClick') onRowDoubleClick=(action 'onRowDoubleClick')}}`);
 
-  let row = this.$('tr:first');
-  row.click();
-  row.dblclick();
+  let [row] = findAll('tr');
+  click(row);
+  triggerEvent(row, 'dblclick');
 });
 
 test('hidden rows', function(assert) {
@@ -175,20 +169,20 @@ test('hidden rows', function(assert) {
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions}}`);
 
-  assert.equal(this.$('tbody > tr').length, 5);
+  assert.equal(findAll('tbody > tr').length, 5);
 
   run(() => {
     this.get('table.rows').objectAt(0).set('hidden', true);
     this.get('table.rows').objectAt(1).set('hidden', true);
   });
 
-  assert.equal(this.$('tbody > tr').length, 3);
+  assert.equal(findAll('tbody > tr').length, 3);
 
   run(() => {
     this.get('table.rows').objectAt(0).set('hidden', false);
   });
 
-  assert.equal(this.$('tbody > tr').length, 4);
+  assert.equal(findAll('tbody > tr').length, 4);
 });
 
 test('scaffolding', function(assert) {
@@ -197,35 +191,21 @@ test('scaffolding', function(assert) {
 
   this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions enableScaffolding=true}}`);
 
-  const scaffoldingRow = this.$('tr:eq(0)');
-  const userRow = this.$('tr:eq(1)');
-  const userCells = userRow.children('.lt-cell');
+  const [scaffoldingRow, userRow] = findAll('tr');
+  const userCells = findAll('.lt-cell', userRow);
+
+  assert.ok(hasClass(scaffoldingRow, 'lt-scaffolding-row'), 'the first row of the <tbody> is a scaffolding row');
+  assert.notOk(hasClass(userRow, 'lt-scaffolding-row'), 'the second row of the <tbody> is not a scaffolding row');
+
+  assert.notOk(userRow.hasAttribute('style'), 'the second row of the <tbody> has no `style` attribute');
 
   assert.ok(
-    scaffoldingRow.hasClass('lt-scaffolding-row'),
-    'the first row of the <tbody> is a scaffolding row'
-  );
-  assert.ok(
-    !userRow.hasClass('lt-scaffolding-row'),
-    'the second row of the <tbody> is not a scaffolding row'
-  );
-
-  assert.equal(
-    userRow.attr('style'),
-    null,
-    'the second row of the <tbody> has no `style` attribute'
-  );
-
-  assert.ok(
-    Columns
-      .map((c, i) => {
-        const configuredWidth = Number.parseInt(c.width, 10);
-        const actualWidth = userCells.eq(i).width();
-
-        return configuredWidth ? configuredWidth === actualWidth : true;
-      })
-      .every(Boolean),
-    'the first actual data row has the correct widths'
+    Columns.map((c, i) => {
+      const configuredWidth = Number.parseInt(c.width, 10);
+      const actualWidth = Number.parseInt(userCells[i].style.width);
+      return configuredWidth ? configuredWidth === actualWidth : true;
+    }).every(Boolean),
+    'the first actual data row has the correct widths assigned'
   );
 });
 
@@ -238,5 +218,5 @@ test('overwrite', function(assert) {
     {{/lt-body}}
   `);
 
-  assert.equal(this.$().text().trim(), '6, 5');
+  assert.equal(find('*').textContent.trim(), '6, 5');
 });

--- a/tests/integration/components/lt-column-resizer-test.js
+++ b/tests/integration/components/lt-column-resizer-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,7 +12,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{lt-column-resizer}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -20,5 +21,5 @@ test('it renders', function(assert) {
     {{/lt-column-resizer}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(find('*').textContent.trim(), 'template block text');
 });

--- a/tests/integration/components/lt-foot-test.js
+++ b/tests/integration/components/lt-foot-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,7 +12,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{lt-foot renderInPlace=true}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 
   // Template block usage:"
   this.render(hbs`
@@ -20,5 +21,5 @@ test('it renders', function(assert) {
     {{/lt-foot}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(find('*').textContent.trim(), 'template block text');
 });

--- a/tests/integration/components/lt-head-test.js
+++ b/tests/integration/components/lt-head-test.js
@@ -1,3 +1,4 @@
+import { click, find, findAll } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Table from 'ember-light-table';
@@ -12,7 +13,7 @@ test('render columns', function(assert) {
 
   this.render(hbs`{{lt-head table=table renderInPlace=true}}`);
 
-  assert.equal(this.$('tr > th').length, 6);
+  assert.equal(findAll('tr > th').length, 6);
 });
 
 test('render grouped columns', function(assert) {
@@ -20,24 +21,25 @@ test('render grouped columns', function(assert) {
 
   this.render(hbs`{{lt-head table=table renderInPlace=true}}`);
 
-  assert.equal(this.$('tr:nth-child(2) > th').attr('colspan'), 3);
-  assert.ok(this.$('tr:nth-child(2) > th').hasClass('lt-group-column'));
-  assert.equal(this.$('tr').length, 3);
-  assert.equal(this.$('tr > th').length, 8);
+  assert.equal(find('tr:nth-child(2) > th').getAttribute('colspan'), 3);
+  assert.ok(find('tr:nth-child(2) > th').classList.contains('lt-group-column'));
+  assert.equal(findAll('tr').length, 3);
+  assert.equal(findAll('tr > th').length, 8);
 });
 
 test('click - non-sortable column', function(assert) {
   this.set('table', new Table(Columns));
   this.on('onColumnClick', (column) => {
     assert.ok(column);
-    assert.ok(!column.sortable);
+    assert.notOk(column.sortable);
     assert.equal(column.label, 'Avatar');
   });
 
   this.render(hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`);
 
-  assert.equal(this.$('tr > th').length, 6);
-  this.$('tr > th:first').click();
+  assert.equal(findAll('tr > th').length, 6);
+  let [nonSortableHeader] = findAll('tr > th');
+  click(nonSortableHeader);
 });
 
 test('click - sortable column', function(assert) {
@@ -52,23 +54,26 @@ test('click - sortable column', function(assert) {
   });
 
   this.render(hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`);
-
-  assert.equal(this.$('tr > th').length, 6);
-  this.$('tr > th:last').click();
+  let allHeaders = findAll('tr > th');
+  let sortableHeader = allHeaders[allHeaders.length - 1];
+  assert.equal(findAll('tr > th').length, 6);
+  click(sortableHeader);
   asc = false;
-  this.$('tr > th:last').click();
+  click(sortableHeader);
 });
 
 test('double click', function(assert) {
   this.set('table', new Table(Columns));
   this.on('onColumnDoubleClick', (column) => {
     assert.ok(column);
-    assert.ok(!column.sortable);
+    assert.notOk(column.sortable);
     assert.equal(column.label, 'Avatar');
   });
 
   this.render(hbs`{{lt-head table=table renderInPlace=true onColumnDoubleClick=(action 'onColumnDoubleClick')}}`);
+  let allHeaders = findAll('tr > th');
+  let sortableHeader = allHeaders[allHeaders.length - 1];
 
-  assert.equal(this.$('tr > th').length, 6);
-  this.$('tr > th:last').click();
+  assert.equal(allHeaders.length, 6);
+  click(sortableHeader);
 });

--- a/tests/integration/components/lt-head-test.js
+++ b/tests/integration/components/lt-head-test.js
@@ -38,7 +38,7 @@ test('click - non-sortable column', function(assert) {
   this.render(hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`);
 
   assert.equal(findAll('tr > th').length, 6);
-  let [nonSortableHeader] = findAll('tr > th');
+  let nonSortableHeader = find('tr > th');
   click(nonSortableHeader);
 });
 

--- a/tests/integration/components/lt-infinity-test.js
+++ b/tests/integration/components/lt-infinity-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,7 +12,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{lt-infinity}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -20,5 +21,5 @@ test('it renders', function(assert) {
     {{/lt-infinity}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(find('*').textContent.trim(), 'template block text');
 });

--- a/tests/integration/components/lt-row-test.js
+++ b/tests/integration/components/lt-row-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,5 +12,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{lt-row}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 });

--- a/tests/integration/components/lt-scrollable-test.js
+++ b/tests/integration/components/lt-scrollable-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,7 +12,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{lt-scrollable}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -20,5 +21,5 @@ test('it renders', function(assert) {
     {{/lt-scrollable}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(find('*').textContent.trim(), 'template block text');
 });

--- a/tests/integration/components/lt-spanned-row-test.js
+++ b/tests/integration/components/lt-spanned-row-test.js
@@ -1,3 +1,4 @@
+import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -7,7 +8,7 @@ moduleForComponent('lt-spanned-row', 'Integration | Component | lt spanned row',
 
 test('it renders', function(assert) {
   this.render(hbs`{{lt-spanned-row}}`);
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 
   this.render(hbs`
     {{#lt-spanned-row}}
@@ -15,7 +16,7 @@ test('it renders', function(assert) {
     {{/lt-spanned-row}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(find('*').textContent.trim(), 'template block text');
 });
 
 test('visiblity', function(assert) {
@@ -26,10 +27,10 @@ test('visiblity', function(assert) {
       template block text
     {{/lt-spanned-row}}
   `);
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(find('*').textContent.trim(), 'template block text');
 
   this.set('visible', false);
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(find('*').textContent.trim(), '');
 });
 
 test('colspan', function(assert) {
@@ -38,8 +39,8 @@ test('colspan', function(assert) {
       template block text
     {{/lt-spanned-row}}
   `);
-  assert.equal(this.$().text().trim(), 'template block text');
-  assert.equal(this.$('td').attr('colspan'), 4);
+  assert.equal(find('*').textContent.trim(), 'template block text');
+  assert.equal(find('td').getAttribute('colspan'), 4);
 });
 
 test('yield', function(assert) {
@@ -49,5 +50,5 @@ test('yield', function(assert) {
       {{row.name}}
     {{/lt-spanned-row}}
   `);
-  assert.equal(this.$().text().trim(), 'Offir');
+  assert.equal(find('*').textContent.trim(), 'Offir');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,6 +3101,13 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-native-dom-helpers@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.0.tgz#a3a12215cfdfa518472e203fdc15b485cea23670"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.1.0"
+
 ember-one-way-controls@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-one-way-controls/-/ember-one-way-controls-2.0.0.tgz#7a79f1a56094c44fe1012fd0f9b75bd92d136fe9"
@@ -3496,21 +3503,21 @@ esrefactor@~0.1.0:
     esprima "~1.0.2"
     estraverse "~0.0.4"
 
-"estraverse@>= 0.0.2", estraverse@~1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
+"estraverse@>= 0.0.2", estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
-
 estraverse@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-0.0.4.tgz#01a0932dfee574684a598af5a67c3bf9b6428db2"
+
+estraverse@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -4083,7 +4090,7 @@ glob-parent@^2.0.0:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@7.1.1, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1:
+glob@7.1.1, glob@^7.0.4, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -4104,7 +4111,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -6578,32 +6585,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@^2.47.0, request@~2.67.0:
-  version "2.67.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.67.0.tgz#8af74780e2bf11ea0ae9aa965c11f11afd272742"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    bl "~1.0.0"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~1.0.0-rc3"
-    har-validator "~2.0.2"
-    hawk "~3.1.0"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    node-uuid "~1.4.7"
-    oauth-sign "~0.8.0"
-    qs "~5.2.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.2.0"
-    tunnel-agent "~0.4.1"
-
-request@^2.72.0, request@^2.81.0:
+request@2, request@^2.47.0, request@^2.72.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -6648,6 +6630,31 @@ request@~2.40.0:
     stringstream "~0.0.4"
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
+
+request@~2.67.0:
+  version "2.67.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.67.0.tgz#8af74780e2bf11ea0ae9aa965c11f11afd272742"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    bl "~1.0.0"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~1.0.0-rc3"
+    har-validator "~2.0.2"
+    hawk "~3.1.0"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    node-uuid "~1.4.7"
+    oauth-sign "~0.8.0"
+    qs "~5.2.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.2.0"
+    tunnel-agent "~0.4.1"
 
 require-dir@^0.3.0:
   version "0.3.2"
@@ -7435,15 +7442,15 @@ to-fast-properties@^1.0.0, to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@>=0.12.0, tough-cookie@~2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.2.2.tgz#c83a1830f4e5ef0b93ef2a3488e724f8de016ac7"
-
-tough-cookie@~2.3.0:
+tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tough-cookie@~2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.2.2.tgz#c83a1830f4e5ef0b93ef2a3488e724f8de016ac7"
 
 tree-sync@^1.2.1, tree-sync@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
As promised. Moving to use `ember-native-dom-helpers` instead of jQuery selectors.
We should investigate using them in the addon code to make it jQuery-less