### PR TITLE
head & foot: make `table.height` optional, warn in `table-header` mixin

### DIFF
--- a/addon/components/lt-foot.js
+++ b/addon/components/lt-foot.js
@@ -3,10 +3,9 @@ import layout from 'ember-light-table/templates/components/lt-foot';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
 const {
-  assert,
   Component,
-  isEmpty,
-  set
+  get,
+  trySet
 } = Ember;
 
 /**
@@ -46,11 +45,6 @@ export default Component.extend(TableHeaderMixin, {
   init() {
     this._super(...arguments);
 
-    let sharedOptions = this.get('sharedOptions') || {};
-    let fixed = this.get('fixed');
-
-    assert('[ember-light-table] The height property is required for fixed footer', !fixed || fixed && !isEmpty(sharedOptions.height));
-
-    set(sharedOptions, 'fixedFooter', fixed);
+    trySet(this, 'sharedOptions.fixedFooter', get(this, 'fixed'));
   }
 });

--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -3,10 +3,9 @@ import layout from 'ember-light-table/templates/components/lt-head';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
 const {
-  assert,
   Component,
-  isEmpty,
-  set
+  get,
+  trySet
 } = Ember;
 
 /**
@@ -48,11 +47,6 @@ export default Component.extend(TableHeaderMixin, {
   init() {
     this._super(...arguments);
 
-    let sharedOptions = this.get('sharedOptions') || {};
-    let fixed = this.get('fixed');
-
-    assert('[ember-light-table] The height property is required for fixed header', !fixed || fixed && !isEmpty(sharedOptions.height));
-
-    set(sharedOptions, 'fixedHeader', fixed);
+    trySet(this, 'sharedOptions.fixedHeader', get(this, 'fixed'));
   }
 });

--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -2,7 +2,9 @@ import Ember from 'ember';
 
 const {
   computed,
-  Mixin
+  isEmpty,
+  Mixin,
+  warn
 } = Ember;
 
 /**
@@ -104,6 +106,19 @@ export default Mixin.create({
   sortIcons: computed('iconAscending', 'iconDescending', function() {
     return this.getProperties(['iconAscending', 'iconDescending']);
   }).readOnly(),
+
+  init() {
+    this._super(...arguments);
+
+    let fixed = this.get('fixed');
+    let height = this.get('sharedOptions.height');
+
+    warn(
+      'You did not set a `height` attribute for your table, but marked a header or footer to be fixed. This means that you have to set the table height via CSS. For more information please refer to:  https://github.com/offirgolan/ember-light-table/issues/446',
+      !fixed || fixed && !isEmpty(height),
+      { id: 'ember-light-table.height-attribute' }
+    );
+  },
 
   actions: {
     /**


### PR DESCRIPTION
Fixes #446.