### PR TITLE
Table: add `setRowsSynced` method

### DIFF
--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -192,6 +192,26 @@ export default class Table extends EmberObject.extend({
   }
 
   /**
+   * The same as `setRows`, however the given array is synced, meaning that
+   * mutating the array also updates the table and vice-versa.
+   *
+   * Also see `enableSync` in the constructor options.
+   *
+   * @method setRowsSynced
+   * @param  {Array} rows
+   * @param  {Object} options
+   * @return {Array} rows
+   */
+  setRowsSynced(rows = [], options = {}) {
+    let _rows = RowSyncArrayProxy.create({
+      syncArray: rows,
+      content: emberArray(Table.createRows(rows, options))
+    });
+
+    return this.set('rows', _rows);
+  }
+
+  /**
    * Push the object onto the end of the row array if it is not already present.
    * @method addRow
    * @param  {Object} row

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -145,15 +145,18 @@ export default class Table extends EmberObject.extend({
    * @param  {Array} columns
    * @param  {Array} rows
    * @param  {Object} options
-   *    - enableSync ( _Boolean_ ): If true, creates a two way sync between the table's rows
-   *                                and the passed rows collection
+   * @param  {Boolean} options.enableSync If `true`, creates a two way sync
+   *           between the table's rows and the passed rows collection. Also see
+   *           `setRowsSynced(rows)`.
+   * @param  {Object}  options.rowOptions Options hash passed through to
+   *           `createRow(content, options)`.
    */
   constructor(columns = [], rows = [], options = {}) {
     super();
 
-    let _columns = emberArray(Table.createColumns(columns));
-    let _rows = emberArray(Table.createRows(rows));
     let _options = mergeOptionsWithGlobals(options);
+    let _columns = emberArray(Table.createColumns(columns));
+    let _rows = emberArray(Table.createRows(rows, _options.rowOptions));
 
     if (_options.enableSync) {
       _rows = RowSyncArrayProxy.create({

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -525,3 +525,27 @@ test('table modifications with sync enabled - sort', function(assert) {
   assert.equal(table.get('rows.length'), rows.get('length'));
   assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
 });
+
+test('setRowsSynced', function(assert) {
+  let initialRows = emberArray([]);
+  let otherRows = emberArray([]);
+  let table = new Table([], initialRows, { enableSync: true });
+  let initialLength = 5;
+  let otherLength = 13;
+
+  for (let i = 0; i < initialLength; i++) {
+    initialRows.pushObject({ position: i });
+  }
+  assert.deepEqual(table.get('rows').getEach('position'), initialRows.getEach('position'), 'the table is initialized with a synced array');
+
+  table.setRowsSynced(otherRows);
+  assert.deepEqual(table.get('rows').getEach('position'), otherRows.getEach('position'), 'the synced array may be replaced');
+
+  for (let i = 0; i < otherLength; i++) {
+    otherRows.pushObject({ position: i });
+  }
+  assert.deepEqual(table.get('rows').getEach('position'), otherRows.getEach('position'), 'the replacement array is correctly synced');
+
+  initialRows.popObject();
+  assert.deepEqual(table.get('rows').getEach('position'), otherRows.getEach('position'), 'mutating the replaced array has no effect');
+});


### PR DESCRIPTION
Fixes #414.

The tests assert that:

- the table is initialized with a synced array
- the synced array may be replaced
- the replacement array is correctly synced
- mutating the replaced array has no effect