### PR TITLE
Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,14 +4,19 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
+  plugins: [
+    'prettier'
+  ],
   extends: [
     'eslint:recommended',
-    'plugin:ember-suave/recommended'
+    'plugin:ember-suave/recommended',
+    'prettier'
   ],
   env: {
     browser: true
   },
   rules: {
+    'prettier/prettier': ['error', { singleQuote: true }],
     'generator-star-spacing': ['error', { before: false, after: false }],
     'ember-suave/require-access-in-comments': 'off',
     'ember-suave/no-const-outside-module-scope': 'off'

--- a/addon/-private/sync-array-proxy.js
+++ b/addon/-private/sync-array-proxy.js
@@ -1,10 +1,6 @@
 import Ember from 'ember';
 
-const {
-  ArrayProxy,
-  assert,
-  isArray
-} = Ember;
+const { ArrayProxy, assert, isArray } = Ember;
 
 const EMPTY_ARRAY = [];
 
@@ -27,7 +23,10 @@ export default ArrayProxy.extend({
 
     let syncArray = this.get('syncArray');
 
-    assert('[ember-light-table] enableSync requires the passed array to be an instance of Ember.A', isArray(syncArray) && typeof syncArray.addArrayObserver === 'function');
+    assert(
+      '[ember-light-table] enableSync requires the passed array to be an instance of Ember.A',
+      isArray(syncArray) && typeof syncArray.addArrayObserver === 'function'
+    );
 
     syncArray.addArrayObserver(this, {
       willChange: 'syncArrayWillChange',
@@ -67,7 +66,9 @@ export default ArrayProxy.extend({
     return objects;
   },
 
-  syncArrayWillChange() { /* Not needed */ },
+  syncArrayWillChange() {
+    /* Not needed */
+  },
 
   syncArrayDidChange(syncArray, start, removeCount, addCount) {
     let content = this.get('content');
@@ -78,7 +79,9 @@ export default ArrayProxy.extend({
     }
 
     if (addCount > 0) {
-      objectsToAdd = this.serializeContentObjects(syncArray.slice(start, start + addCount));
+      objectsToAdd = this.serializeContentObjects(
+        syncArray.slice(start, start + addCount)
+      );
     }
 
     content.replace(start, removeCount, objectsToAdd);
@@ -91,6 +94,10 @@ export default ArrayProxy.extend({
       return this._super(...arguments);
     }
 
-    syncArray.replace(start, removeCount, this.serializeSyncArrayObjects(objectsToAdd));
+    syncArray.replace(
+      start,
+      removeCount,
+      this.serializeSyncArrayObjects(objectsToAdd)
+    );
   }
 });

--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -305,21 +305,30 @@ export default class Column extends EmberObject.extend({
    * @type {Boolean}
    * @private
    */
-  isVisibleGroupColumn: computed('visibleSubColumns.[]', 'isHidden', function() {
-    return !isEmpty(this.get('visibleSubColumns')) && !this.get('isHidden');
-  }).readOnly(),
+  isVisibleGroupColumn: computed(
+    'visibleSubColumns.[]',
+    'isHidden',
+    function() {
+      return !isEmpty(this.get('visibleSubColumns')) && !this.get('isHidden');
+    }
+  ).readOnly(),
 
   /**
    * @property visibleSubColumns
    * @type {Array}
    * @private
    */
-  visibleSubColumns: computed('subColumns.[]', 'subColumns.@each.isHidden', 'isHidden', function() {
-    let subColumns = this.get('subColumns');
-    let isHidden = this.get('isHidden');
+  visibleSubColumns: computed(
+    'subColumns.[]',
+    'subColumns.@each.isHidden',
+    'isHidden',
+    function() {
+      let subColumns = this.get('subColumns');
+      let isHidden = this.get('isHidden');
 
-    return emberArray(isHidden ? [] : subColumns.filterBy('isHidden', false));
-  }).readOnly()
+      return emberArray(isHidden ? [] : subColumns.filterBy('isHidden', false));
+    }
+  ).readOnly()
 }) {
   /**
    * @class Column
@@ -339,7 +348,7 @@ export default class Column extends EmberObject.extend({
 
     let { subColumns } = options;
 
-    subColumns = emberArray(makeArray(subColumns).map((sc) => new Column(sc)));
+    subColumns = emberArray(makeArray(subColumns).map(sc => new Column(sc)));
     subColumns.setEach('parent', this);
 
     this.set('subColumns', subColumns);

--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -1,11 +1,7 @@
 import Ember from 'ember';
 import fixProto from 'ember-light-table/utils/fix-proto';
 
-const {
-  computed,
-  guidFor,
-  ObjectProxy
-} = Ember;
+const { computed, guidFor, ObjectProxy } = Ember;
 
 /**
  * @module Table

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -8,6 +8,7 @@ import fixProto from 'ember-light-table/utils/fix-proto';
 const {
   get,
   computed,
+  computed: { empty, filterBy },
   isNone,
   A: emberArray,
   Object: EmberObject
@@ -19,7 +20,7 @@ const RowSyncArrayProxy = SyncArrayProxy.extend({
   },
 
   serializeSyncArrayObjects(objects) {
-    return objects.map((o) => get(o, 'content'));
+    return objects.map(o => get(o, 'content'));
   }
 });
 
@@ -51,82 +52,99 @@ export default class Table extends EmberObject.extend({
    * @property isEmpty
    * @type {Boolean}
    */
-  isEmpty: computed.empty('rows').readOnly(),
+  isEmpty: empty('rows').readOnly(),
 
   /**
    * @property expandedRows
    * @type {Ember.Array}
    */
-  expandedRows: computed.filterBy('rows', 'expanded', true).readOnly(),
+  expandedRows: filterBy('rows', 'expanded', true).readOnly(),
 
   /**
    * @property selectedRows
    * @type {Ember.Array}
    */
-  selectedRows: computed.filterBy('rows', 'selected', true).readOnly(),
+  selectedRows: filterBy('rows', 'selected', true).readOnly(),
 
   /**
    * @property visibleRows
    * @type {Ember.Array}
    */
-  visibleRows: computed.filterBy('rows', 'hidden', false).readOnly(),
+  visibleRows: filterBy('rows', 'hidden', false).readOnly(),
 
   /**
    * @property sortableColumns
    * @type {Ember.Array}
    */
-  sortableColumns: computed.filterBy('visibleColumns', 'sortable', true).readOnly(),
+  sortableColumns: filterBy('visibleColumns', 'sortable', true).readOnly(),
 
   /**
    * @property sortedColumns
    * @type {Ember.Array}
    */
-  sortedColumns: computed.filterBy('visibleColumns', 'sorted', true).readOnly(),
+  sortedColumns: filterBy('visibleColumns', 'sorted', true).readOnly(),
 
   /**
    * @property hideableColumns
    * @type {Ember.Array}
    */
-  hideableColumns: computed.filterBy('allColumns', 'hideable', true).readOnly(),
+  hideableColumns: filterBy('allColumns', 'hideable', true).readOnly(),
 
   /**
    * @property hiddenColumns
    * @type {Ember.Array}
    */
-  hiddenColumns: computed.filterBy('allColumns', 'hidden', true).readOnly(),
+  hiddenColumns: filterBy('allColumns', 'hidden', true).readOnly(),
 
   /**
    * @property responsiveHiddenColumns
    * @type {Ember.Array}
    */
-  responsiveHiddenColumns: computed.filterBy('allColumns', 'responsiveHidden', true).readOnly(),
+  responsiveHiddenColumns: filterBy(
+    'allColumns',
+    'responsiveHidden',
+    true
+  ).readOnly(),
 
   /**
    * @property visibleColumns
    * @type {Ember.Array}
    */
-  visibleColumns: computed.filterBy('allColumns', 'isHidden', false).readOnly(),
+  visibleColumns: filterBy('allColumns', 'isHidden', false).readOnly(),
 
   /**
    * @property visibleColumnGroups
    * @type {Ember.Array}
    */
-  visibleColumnGroups: computed('columns.[]', 'columns.@each.{isHidden,isVisibleGroupColumn}', function() {
-    return this.get('columns').reduce((arr, c) => {
-      if (c.get('isVisibleGroupColumn') || (!c.get('isGroupColumn') && !c.get('isHidden'))) {
-        arr.pushObject(c);
-      }
-      return arr;
-    }, emberArray([]));
-  }).readOnly(),
+  visibleColumnGroups: computed(
+    'columns.[]',
+    'columns.@each.{isHidden,isVisibleGroupColumn}',
+    function() {
+      return this.get('columns').reduce((arr, c) => {
+        if (
+          c.get('isVisibleGroupColumn') ||
+          (!c.get('isGroupColumn') && !c.get('isHidden'))
+        ) {
+          arr.pushObject(c);
+        }
+        return arr;
+      }, emberArray([]));
+    }
+  ).readOnly(),
 
   /**
    * @property visibleSubColumns
    * @type {Ember.Array}
    */
-  visibleSubColumns: computed('columns.[]', 'columns.@each.visibleSubColumns', function() {
-    return emberArray([].concat(...this.get('columns').getEach('visibleSubColumns')));
-  }).readOnly(),
+  visibleSubColumns: computed(
+    'columns.[]',
+    'columns.@each.visibleSubColumns',
+    function() {
+      return emberArray(
+        [].concat(...this.get('columns').getEach('visibleSubColumns'))
+      );
+    }
+  ).readOnly(),
 
   /**
    * @property allColumns
@@ -235,7 +253,7 @@ export default class Table extends EmberObject.extend({
    * @param  {Object} options
    */
   addRows(rows = [], options = {}) {
-    rows.forEach((r) => this.addRow(r, options));
+    rows.forEach(r => this.addRow(r, options));
   }
 
   /**
@@ -297,7 +315,7 @@ export default class Table extends EmberObject.extend({
    * @param  {Array}    rows
    */
   removeRows(rows = []) {
-    rows.forEach((r) => this.removeRow(r));
+    rows.forEach(r => this.removeRow(r));
   }
 
   /**
@@ -424,7 +442,7 @@ export default class Table extends EmberObject.extend({
    * @return {Array}
    */
   static createRows(rows = [], options = {}) {
-    return rows.map((r) => Table.createRow(r, options));
+    return rows.map(r => Table.createRow(r, options));
   }
 
   /**
@@ -446,7 +464,7 @@ export default class Table extends EmberObject.extend({
    * @return {Array}
    */
   static createColumns(columns = []) {
-    return columns.map((c) => Table.createColumn(c));
+    return columns.map(c => Table.createColumn(c));
   }
 }
 

--- a/addon/components/cells/base.js
+++ b/addon/components/cells/base.js
@@ -2,10 +2,7 @@ import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/cells/base';
 import cssStyleify from 'ember-light-table/utils/css-styleify';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 /**
  * @module Light Table

--- a/addon/components/columns/base.js
+++ b/addon/components/columns/base.js
@@ -3,11 +3,7 @@ import layout from 'ember-light-table/templates/components/columns/base';
 import DraggableColumnMixin from 'ember-light-table/mixins/draggable-column';
 import cssStyleify from 'ember-light-table/utils/css-styleify';
 
-const {
-  Component,
-  computed,
-  isEmpty
-} = Ember;
+const { Component, computed, computed: { reads }, isEmpty } = Ember;
 
 /**
  * @module Light Table
@@ -24,7 +20,17 @@ const Column = Component.extend(DraggableColumnMixin, {
   tagName: 'th',
   classNames: ['lt-column'],
   attributeBindings: ['style', 'colspan', 'rowspan'],
-  classNameBindings: ['align', 'isGroupColumn:lt-group-column', 'isHideable', 'isSortable', 'isSorted', 'isResizable', 'isResizing', 'isDraggable', 'column.classNames'],
+  classNameBindings: [
+    'align',
+    'isGroupColumn:lt-group-column',
+    'isHideable',
+    'isSortable',
+    'isSorted',
+    'isResizable',
+    'isResizing',
+    'isDraggable',
+    'column.classNames'
+  ],
 
   isGroupColumn: computed.readOnly('column.isGroupColumn'),
   isSortable: computed.readOnly('column.sortable'),
@@ -46,7 +52,7 @@ const Column = Component.extend(DraggableColumnMixin, {
    * @property label
    * @type {String}
    */
-  label: computed.oneWay('column.label'),
+  label: reads('column.label'),
 
   /**
    * @property table

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -16,7 +16,7 @@ const {
 } = Ember;
 
 function intersections(array1, array2) {
-  return array1.filter((n) => {
+  return array1.filter(n => {
     return array2.indexOf(n) > -1;
   });
 }
@@ -167,34 +167,38 @@ const LightTable = Component.extend({
    * @type {Number}
    * @private
    */
-  totalWidth: computed('visibleColumns.[]', 'visibleColumns.@each.width', function() {
-    let visibleColumns = this.get('visibleColumns');
-    let widths = visibleColumns.getEach('width');
-    let unit = (widths[0] || '').match(/\D+$/);
-    let totalWidth = 0;
+  totalWidth: computed(
+    'visibleColumns.[]',
+    'visibleColumns.@each.width',
+    function() {
+      let visibleColumns = this.get('visibleColumns');
+      let widths = visibleColumns.getEach('width');
+      let unit = (widths[0] || '').match(/\D+$/);
+      let totalWidth = 0;
 
-    if (isEmpty(unit)) {
-      return 0;
-    }
-
-    unit = unit[0];
-
-    /*
-      1. Check if all widths are present
-      2. Check if all widths are the same unit
-     */
-    for (let i = 0; i < widths.length; i++) {
-      let width = widths[i];
-
-      if (isNone(width) || width.indexOf(unit) === -1) {
+      if (isEmpty(unit)) {
         return 0;
       }
 
-      totalWidth += parseInt(width, 10);
-    }
+      unit = unit[0];
 
-    return `${totalWidth}${unit}`;
-  }),
+      /*
+      1. Check if all widths are present
+      2. Check if all widths are the same unit
+     */
+      for (let i = 0; i < widths.length; i++) {
+        let width = widths[i];
+
+        if (isNone(width) || width.indexOf(unit) === -1) {
+          return 0;
+        }
+
+        totalWidth += parseInt(width, 10);
+      }
+
+      return `${totalWidth}${unit}`;
+    }
+  ),
 
   style: computed('totalWidth', 'height', function() {
     let totalWidth = this.get('totalWidth');
@@ -214,44 +218,52 @@ const LightTable = Component.extend({
     let table = this.get('table');
     let media = this.get('media');
 
-    assert('[ember-light-table] table must be an instance of Table', table instanceof Table);
+    assert(
+      '[ember-light-table] table must be an instance of Table',
+      table instanceof Table
+    );
 
     if (isNone(media)) {
       this.set('responsive', false);
     }
   },
 
-  onMediaChange: on('init', observer('media.matches.[]', 'table.allColumns.[]', function() {
-    let responsive = this.get('responsive');
-    let matches = this.get('media.matches');
-    let breakpoints = this.get('breakpoints');
-    let table = this.get('table');
-    let numColumns = 0;
+  onMediaChange: on(
+    'init',
+    observer('media.matches.[]', 'table.allColumns.[]', function() {
+      let responsive = this.get('responsive');
+      let matches = this.get('media.matches');
+      let breakpoints = this.get('breakpoints');
+      let table = this.get('table');
+      let numColumns = 0;
 
-    if (!responsive) {
-      return;
-    }
+      if (!responsive) {
+        return;
+      }
 
-    this.send('onBeforeResponsiveChange', matches);
+      this.send('onBeforeResponsiveChange', matches);
 
-    if (!isNone(breakpoints)) {
-      Object.keys(breakpoints).forEach((b) => {
-        if (matches.indexOf(b) > -1) {
-          numColumns = Math.max(numColumns, breakpoints[b]);
-        }
-      });
+      if (!isNone(breakpoints)) {
+        Object.keys(breakpoints).forEach(b => {
+          if (matches.indexOf(b) > -1) {
+            numColumns = Math.max(numColumns, breakpoints[b]);
+          }
+        });
 
-      this._displayColumns(numColumns);
-    } else {
-      table.get('allColumns').forEach((c) => {
-        let breakpoints = c.get('breakpoints');
-        let isMatch = isEmpty(breakpoints) || intersections(matches, breakpoints).length > 0;
-        c.set('responsiveHidden', !isMatch);
-      });
-    }
+        this._displayColumns(numColumns);
+      } else {
+        table.get('allColumns').forEach(c => {
+          let breakpoints = c.get('breakpoints');
+          let isMatch =
+            isEmpty(breakpoints) ||
+            intersections(matches, breakpoints).length > 0;
+          c.set('responsiveHidden', !isMatch);
+        });
+      }
 
-    this.send('onAfterResponsiveChange', matches);
-  })),
+      this.send('onAfterResponsiveChange', matches);
+    })
+  ),
 
   _displayColumns(numColumns) {
     let table = this.get('table');
@@ -261,9 +273,13 @@ const LightTable = Component.extend({
     if (!numColumns) {
       hiddenColumns.setEach('responsiveHidden', false);
     } else if (visibleColumns.length > numColumns) {
-      emberArray(visibleColumns.slice(numColumns, visibleColumns.length)).setEach('responsiveHidden', true);
+      emberArray(
+        visibleColumns.slice(numColumns, visibleColumns.length)
+      ).setEach('responsiveHidden', true);
     } else if (visibleColumns.length < numColumns) {
-      emberArray(hiddenColumns.slice(0, numColumns - visibleColumns.length)).setEach('responsiveHidden', false);
+      emberArray(
+        hiddenColumns.slice(0, numColumns - visibleColumns.length)
+      ).setEach('responsiveHidden', false);
     }
   },
 

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -2,12 +2,7 @@ import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-body';
 import Row from 'ember-light-table/classes/Row';
 
-const {
-  Component,
-  computed,
-  run,
-  observer
-} = Ember;
+const { Component, computed, run, observer } = Ember;
 
 /**
  * @module Light Table
@@ -327,7 +322,11 @@ export default Component.extend({
   },
 
   onRowsChange: observer('rows.[]', function() {
-    this._checkTargetOffsetTimer = run.scheduleOnce('afterRender', this, this.checkTargetScrollOffset);
+    this._checkTargetOffsetTimer = run.scheduleOnce(
+      'afterRender',
+      this,
+      this.checkTargetScrollOffset
+    );
   }),
 
   setupScrollOffset() {
@@ -336,7 +335,12 @@ export default Component.extend({
       _scrollTo,
       scrollToRow,
       _scrollToRow
-    } = this.getProperties(['scrollTo', '_scrollTo', 'scrollToRow', '_scrollToRow']);
+    } = this.getProperties([
+      'scrollTo',
+      '_scrollTo',
+      'scrollToRow',
+      '_scrollToRow'
+    ]);
     let targetScrollOffset = null;
 
     this.setProperties({ _scrollTo: scrollTo, _scrollToRow: scrollToRow });
@@ -354,14 +358,19 @@ export default Component.extend({
       });
     } else if (scrollToRow !== _scrollToRow) {
       if (scrollToRow instanceof Row) {
-        let rowElement = this.element.querySelector(`[data-row-id=${scrollToRow.get('rowId')}]`);
+        let rowElement = this.element.querySelector(
+          `[data-row-id=${scrollToRow.get('rowId')}]`
+        );
 
         if (rowElement instanceof Element) {
           targetScrollOffset = rowElement.offsetTop;
         }
       }
 
-      this.setProperties({ targetScrollOffset, hasReachedTargetScrollOffset: true });
+      this.setProperties({
+        targetScrollOffset,
+        hasReachedTargetScrollOffset: true
+      });
     }
   },
 
@@ -410,7 +419,8 @@ export default Component.extend({
       let expandOnClick = this.get('expandOnClick');
       let isSelected = row.get('selected');
       let currIndex = rows.indexOf(row);
-      let prevIndex = this._prevSelectedIndex === -1 ? currIndex : this._prevSelectedIndex;
+      let prevIndex =
+        this._prevSelectedIndex === -1 ? currIndex : this._prevSelectedIndex;
 
       this._prevSelectedIndex = currIndex;
 
@@ -423,9 +433,15 @@ export default Component.extend({
       if (canSelect) {
         if (e.shiftKey && multiSelect) {
           rows
-            .slice(Math.min(currIndex, prevIndex), Math.max(currIndex, prevIndex) + 1)
-            .forEach((r) => r.set('selected', !isSelected));
-        } else if ((!multiSelectRequiresKeyboard || (e.ctrlKey || e.metaKey)) && multiSelect) {
+            .slice(
+              Math.min(currIndex, prevIndex),
+              Math.max(currIndex, prevIndex) + 1
+            )
+            .forEach(r => r.set('selected', !isSelected));
+        } else if (
+          (!multiSelectRequiresKeyboard || (e.ctrlKey || e.metaKey)) &&
+          multiSelect
+        ) {
           row.toggleProperty('selected');
         } else {
           if (selectOnClick) {

--- a/addon/components/lt-column-resizer.js
+++ b/addon/components/lt-column-resizer.js
@@ -1,11 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/lt-column-resizer';
 
-const {
-  $,
-  Component,
-  computed
-} = Ember;
+const { $, Component, computed } = Ember;
 
 const TOP_LEVEL_CLASS = '.ember-light-table';
 
@@ -21,7 +17,9 @@ export default Component.extend({
 
   $column: computed(function() {
     return $(this.get('element')).parent('th');
-  }).volatile().readOnly(),
+  })
+    .volatile()
+    .readOnly(),
 
   didInsertElement() {
     this._super(...arguments);
@@ -87,15 +85,23 @@ export default Component.extend({
       let resizeOnDrag = this.get('resizeOnDrag');
       let minResizeWidth = this.get('column.minResizeWidth');
       let { startX, startWidth } = this.getProperties(['startX', 'startWidth']);
-      let width = `${Math.max(startWidth + (e.pageX - startX), minResizeWidth)}px`;
+      let width = `${Math.max(
+        startWidth + (e.pageX - startX),
+        minResizeWidth
+      )}px`;
 
       let $column = this.get('$column');
-      let $index = this.get('table.visibleColumns').indexOf(this.get('column')) + 1;
+      let $index =
+        this.get('table.visibleColumns').indexOf(this.get('column')) + 1;
       let $table = this.$().closest(TOP_LEVEL_CLASS);
 
       $column.outerWidth(width);
-      $(`thead td.lt-scaffolding:nth-child(${$index})`, $table).outerWidth(width);
-      $(`tfoot td.lt-scaffolding:nth-child(${$index})`, $table).outerWidth(width);
+      $(`thead td.lt-scaffolding:nth-child(${$index})`, $table).outerWidth(
+        width
+      );
+      $(`tfoot td.lt-scaffolding:nth-child(${$index})`, $table).outerWidth(
+        width
+      );
 
       if (resizeOnDrag) {
         $(`tbody td:nth-child(${$index})`, $table).outerWidth(width);

--- a/addon/components/lt-foot.js
+++ b/addon/components/lt-foot.js
@@ -2,11 +2,7 @@ import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-foot';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
-const {
-  Component,
-  get,
-  trySet
-} = Ember;
+const { Component, get, trySet } = Ember;
 
 /**
  * @module Light Table

--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -2,11 +2,7 @@ import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-head';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
 
-const {
-  Component,
-  get,
-  trySet
-} = Ember;
+const { Component, get, trySet } = Ember;
 
 /**
  * @module Light Table

--- a/addon/components/lt-infinity.js
+++ b/addon/components/lt-infinity.js
@@ -2,11 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/lt-infinity';
 import InViewportMixin from 'ember-in-viewport';
 
-const {
-  Component,
-  observer,
-  run
-} = Ember;
+const { Component, observer, run } = Ember;
 
 export default Component.extend(InViewportMixin, {
   classNames: ['lt-infinity'],
@@ -56,7 +52,11 @@ export default Component.extend(InViewportMixin, {
   }),
 
   _scheduleScrolledToBottom() {
-    this._schedulerTimer = run.scheduleOnce('afterRender', this, this._debounceScrolledToBottom);
+    this._schedulerTimer = run.scheduleOnce(
+      'afterRender',
+      this,
+      this._debounceScrolledToBottom
+    );
   },
 
   _debounceScrolledToBottom(delay = 100) {
@@ -64,7 +64,12 @@ export default Component.extend(InViewportMixin, {
       This debounce is needed when there is not enough delay between onScrolledToBottom calls.
       Without this debounce, all rows will be rendered causing immense performance problems
      */
-    this._debounceTimer = run.debounce(this, this.sendAction, 'onScrolledToBottom', delay);
+    this._debounceTimer = run.debounce(
+      this,
+      this.sendAction,
+      'onScrolledToBottom',
+      delay
+    );
   },
 
   _cancelTimers() {

--- a/addon/components/lt-row.js
+++ b/addon/components/lt-row.js
@@ -1,16 +1,19 @@
 import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-row';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 const Row = Component.extend({
   layout,
   tagName: 'tr',
   classNames: ['lt-row'],
-  classNameBindings: ['isSelected', 'isExpanded', 'canExpand:is-expandable', 'canSelect:is-selectable', 'row.classNames'],
+  classNameBindings: [
+    'isSelected',
+    'isExpanded',
+    'canExpand:is-expandable',
+    'canSelect:is-selectable',
+    'row.classNames'
+  ],
   attributeBindings: ['colspan', 'data-row-id'],
 
   columns: null,

--- a/addon/components/lt-scrollable.js
+++ b/addon/components/lt-scrollable.js
@@ -1,9 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/lt-scrollable';
 
-const {
-  Component
-} = Ember;
+const { Component } = Ember;
 
 export default Component.extend({
   layout,

--- a/addon/components/lt-spanned-row.js
+++ b/addon/components/lt-spanned-row.js
@@ -1,9 +1,7 @@
 import Ember from 'ember';
 import layout from 'ember-light-table/templates/components/lt-spanned-row';
 
-const {
-  Component
-} = Ember;
+const { Component } = Ember;
 
 export default Component.extend({
   layout,

--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -1,10 +1,6 @@
 import Ember from 'ember';
 
-const {
-  run,
-  computed,
-  Mixin
-} = Ember;
+const { run, computed, Mixin } = Ember;
 
 let sourceColumn;
 
@@ -20,7 +16,7 @@ export default Mixin.create({
       let columns = this.get('dragColumnGroup');
       let targetIdx = columns.indexOf(this.get('column'));
       let sourceIdx = columns.indexOf(sourceColumn);
-      let direction = (sourceIdx - targetIdx) < 0 ? 'right' : 'left';
+      let direction = sourceIdx - targetIdx < 0 ? 'right' : 'left';
 
       return `drag-${direction}`;
     }
@@ -45,8 +41,13 @@ export default Mixin.create({
     /*
       A column is a valid drop target only if its in the same group
      */
-    return column.get('droppable') && column.get('parent') === sourceColumn.get('parent');
-  }).volatile().readOnly(),
+    return (
+      column.get('droppable') &&
+      column.get('parent') === sourceColumn.get('parent')
+    );
+  })
+    .volatile()
+    .readOnly(),
 
   dragStart(e) {
     this._super(...arguments);
@@ -110,7 +111,7 @@ export default Mixin.create({
     /*
       Restore click event
      */
-    this._clickResetTimer = run.next(this, () => this.click = this.__click__);
+    this._clickResetTimer = run.next(this, () => (this.click = this.__click__));
   },
 
   drop(e) {

--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -1,11 +1,6 @@
 import Ember from 'ember';
 
-const {
-  computed,
-  isEmpty,
-  Mixin,
-  warn
-} = Ember;
+const { computed, isEmpty, Mixin, warn } = Ember;
 
 /**
  * @module Light Table
@@ -115,7 +110,7 @@ export default Mixin.create({
 
     warn(
       'You did not set a `height` attribute for your table, but marked a header or footer to be fixed. This means that you have to set the table height via CSS. For more information please refer to:  https://github.com/offirgolan/ember-light-table/issues/446',
-      !fixed || fixed && !isEmpty(height),
+      !fixed || (fixed && !isEmpty(height)),
       { id: 'ember-light-table.height-attribute' }
     );
   },

--- a/addon/utils/css-styleify.js
+++ b/addon/utils/css-styleify.js
@@ -1,17 +1,11 @@
 import Ember from 'ember';
 
-const {
-  isPresent,
-  String: {
-    dasherize,
-    htmlSafe
-  }
-} = Ember;
+const { isPresent, String: { dasherize, htmlSafe } } = Ember;
 
 export default function cssStyleify(hash = {}) {
   let styles = [];
 
-  Object.keys(hash).forEach((key) => {
+  Object.keys(hash).forEach(key => {
     let value = hash[key];
 
     if (isPresent(value)) {

--- a/addon/utils/fix-proto.js
+++ b/addon/utils/fix-proto.js
@@ -27,6 +27,7 @@
  * @type {Boolean}
  * @readOnly
  */
+// prettier-ignore
 export const isProtoSupported = ({ __proto__: [] }) instanceof Array;
 
 /**

--- a/config/changelog.js
+++ b/config/changelog.js
@@ -2,7 +2,6 @@
 
 // For details on each option run `ember help release`
 module.exports = {
-
   // angular style guide: https://github.com/angular/angular.js/blob/v1.4.8/CONTRIBUTING.md#commit
   // jquery style guide: https://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines
   // ember style guide: https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#commit-tagging
@@ -19,5 +18,4 @@ module.exports = {
      format: function(commit) { return commit.title; },
      */
   }
-
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+/* eslint-disable prettier/prettier */
 module.exports = {
   useVersionCompatibility: true,
   scenarios: [

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {};
 };

--- a/config/release.js
+++ b/config/release.js
@@ -1,20 +1,21 @@
-/* jshint node:true */
-/* var RSVP = require('rsvp'); */
-var execSync = require('child_process').execSync;
-var generateChangelog = require('ember-cli-changelog/lib/tasks/release-with-changelog');
+/* eslint-env node */
+let execSync = require('child_process').execSync;
+let generateChangelog = require('ember-cli-changelog/lib/tasks/release-with-changelog');
 
 module.exports = {
   publish: true,
   beforeCommit: generateChangelog,
-  afterPublish: function(project, versions) {
+  afterPublish(project, versions) {
     // Publish dummy app with docs to gh-pages
-    runCommand('ember github-pages:commit --message "Released ' + versions.next + '"');
+    runCommand(
+      `ember github-pages:commit --message "Released ${versions.next}"`
+    );
     runCommand('git push origin gh-pages:gh-pages');
   }
 };
 
 function runCommand(command) {
-  console.log('running: ' + command);
-  var output = execSync(command, { encoding: 'utf8' });
+  console.log(`running: ${command}`);
+  let output = execSync(command, { encoding: 'utf8' });
   console.log(output);
 }

--- a/package.json
+++ b/package.json
@@ -68,8 +68,11 @@
     "ember-resolver": "^4.0.0",
     "ember-responsive": "^2.0.4",
     "ember-source": "~2.13.0",
+    "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-ember-suave": "^1.0.0",
+    "eslint-plugin-prettier": "^2.1.2",
     "loader.js": "^4.2.3",
+    "prettier": "^1.5.3",
     "yuidoc-ember-theme": "^1.2.1"
   },
   "engines": {

--- a/testem.js
+++ b/testem.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, prettier/prettier */
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,9 +3,7 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const {
-  Application
-} = Ember;
+const { Application } = Ember;
 
 const App = Application.extend({
   modulePrefix: config.modulePrefix,

--- a/tests/dummy/app/breakpoints.js
+++ b/tests/dummy/app/breakpoints.js
@@ -1,7 +1,6 @@
-/* eslint-disable key-spacing */
 export default {
-  mobile:  '(max-width: 768px)',
-  tablet:  '(min-width: 769px) and (max-width: 992px)',
+  mobile: '(max-width: 768px)',
+  tablet: '(min-width: 769px) and (max-width: 992px)',
   desktop: '(min-width: 993px) and (max-width: 1200px)',
-  jumbo:   '(min-width: 1201px)'
+  jumbo: '(min-width: 1201px)'
 };

--- a/tests/dummy/app/components/colored-row.js
+++ b/tests/dummy/app/components/colored-row.js
@@ -2,10 +2,7 @@
 import Ember from 'ember';
 import Row from 'ember-light-table/components/lt-row';
 
-const {
-  computed,
-  String: { htmlSafe }
-} = Ember;
+const { computed, String: { htmlSafe } } = Ember;
 
 export default Row.extend({
   classNames: ['colored-row'],

--- a/tests/dummy/app/components/columns/draggable-table.js
+++ b/tests/dummy/app/components/columns/draggable-table.js
@@ -2,55 +2,63 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'User Details',
-      sortable: false,
-      align: 'center',
-      draggable: true,
-      subColumns: [{
-        label: 'Avatar',
-        valuePath: 'avatar',
-        width: '60px',
+    return [
+      {
+        label: 'User Details',
         sortable: false,
+        align: 'center',
         draggable: true,
-        cellComponent: 'user-avatar'
-      }, {
-        label: 'First',
-        valuePath: 'firstName',
-        width: '150px',
-        draggable: true
-      }, {
-        label: 'Last',
-        valuePath: 'lastName',
-        width: '150px',
-        draggable: true
-      }]
-    }, {
-      label: 'Contact Information',
-      sortable: false,
-      align: 'center',
-      draggable: true,
-      subColumns: [{
-        label: 'Address',
-        valuePath: 'address',
-        draggable: true
-      }, {
-        label: 'State',
-        valuePath: 'state',
-        draggable: true
-      }, {
-        label: 'Country',
-        valuePath: 'country',
-        draggable: true
-      }]
-    }];
+        subColumns: [
+          {
+            label: 'Avatar',
+            valuePath: 'avatar',
+            width: '60px',
+            sortable: false,
+            draggable: true,
+            cellComponent: 'user-avatar'
+          },
+          {
+            label: 'First',
+            valuePath: 'firstName',
+            width: '150px',
+            draggable: true
+          },
+          {
+            label: 'Last',
+            valuePath: 'lastName',
+            width: '150px',
+            draggable: true
+          }
+        ]
+      },
+      {
+        label: 'Contact Information',
+        sortable: false,
+        align: 'center',
+        draggable: true,
+        subColumns: [
+          {
+            label: 'Address',
+            valuePath: 'address',
+            draggable: true
+          },
+          {
+            label: 'State',
+            valuePath: 'state',
+            draggable: true
+          },
+          {
+            label: 'Country',
+            valuePath: 'country',
+            draggable: true
+          }
+        ]
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/columns/grouped-table.js
+++ b/tests/dummy/app/components/columns/grouped-table.js
@@ -2,49 +2,57 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'User Details',
-      sortable: false,
-      align: 'center',
-
-      subColumns: [{
-        label: 'Avatar',
-        valuePath: 'avatar',
-        width: '60px',
+    return [
+      {
+        label: 'User Details',
         sortable: false,
-        cellComponent: 'user-avatar'
-      }, {
-        label: 'First',
-        valuePath: 'firstName',
-        width: '150px'
-      }, {
-        label: 'Last',
-        valuePath: 'lastName',
-        width: '150px'
-      }]
-    }, {
-      label: 'Contact Information',
-      sortable: false,
-      align: 'center',
+        align: 'center',
 
-      subColumns: [{
-        label: 'Address',
-        valuePath: 'address'
-      }, {
-        label: 'State',
-        valuePath: 'state'
-      }, {
-        label: 'Country',
-        valuePath: 'country'
-      }]
-    }];
+        subColumns: [
+          {
+            label: 'Avatar',
+            valuePath: 'avatar',
+            width: '60px',
+            sortable: false,
+            cellComponent: 'user-avatar'
+          },
+          {
+            label: 'First',
+            valuePath: 'firstName',
+            width: '150px'
+          },
+          {
+            label: 'Last',
+            valuePath: 'lastName',
+            width: '150px'
+          }
+        ]
+      },
+      {
+        label: 'Contact Information',
+        sortable: false,
+        align: 'center',
+
+        subColumns: [
+          {
+            label: 'Address',
+            valuePath: 'address'
+          },
+          {
+            label: 'State',
+            valuePath: 'state'
+          },
+          {
+            label: 'Country',
+            valuePath: 'country'
+          }
+        ]
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/columns/resizable-table.js
+++ b/tests/dummy/app/components/columns/resizable-table.js
@@ -2,59 +2,67 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'User Details',
-      sortable: false,
-      align: 'center',
-
-      subColumns: [{
-        label: 'Avatar',
-        valuePath: 'avatar',
-        width: '60px',
+    return [
+      {
+        label: 'User Details',
         sortable: false,
-        cellComponent: 'user-avatar'
-      }, {
-        label: 'First',
-        resizable: true,
-        valuePath: 'firstName',
-        width: '150px',
-        minResizeWidth: 75
-      }, {
-        label: 'Last',
-        resizable: true,
-        valuePath: 'lastName',
-        width: '150px',
-        minResizeWidth: 75
-      }]
-    }, {
-      label: 'Contact Information',
-      sortable: false,
-      align: 'center',
+        align: 'center',
 
-      subColumns: [{
-        label: 'Address',
-        resizable: true,
-        valuePath: 'address',
-        minResizeWidth: 100
-      }, {
-        label: 'State',
-        resizable: true,
-        valuePath: 'state',
-        minResizeWidth: 100
-      }, {
-        label: 'Country',
-        resizable: true,
-        valuePath: 'country',
-        minResizeWidth: 100
-      }]
-    }];
+        subColumns: [
+          {
+            label: 'Avatar',
+            valuePath: 'avatar',
+            width: '60px',
+            sortable: false,
+            cellComponent: 'user-avatar'
+          },
+          {
+            label: 'First',
+            resizable: true,
+            valuePath: 'firstName',
+            width: '150px',
+            minResizeWidth: 75
+          },
+          {
+            label: 'Last',
+            resizable: true,
+            valuePath: 'lastName',
+            width: '150px',
+            minResizeWidth: 75
+          }
+        ]
+      },
+      {
+        label: 'Contact Information',
+        sortable: false,
+        align: 'center',
+
+        subColumns: [
+          {
+            label: 'Address',
+            resizable: true,
+            valuePath: 'address',
+            minResizeWidth: 100
+          },
+          {
+            label: 'State',
+            resizable: true,
+            valuePath: 'state',
+            minResizeWidth: 100
+          },
+          {
+            label: 'Country',
+            resizable: true,
+            valuePath: 'country',
+            minResizeWidth: 100
+          }
+        ]
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/cookbook/client-side-table.js
+++ b/tests/dummy/app/components/cookbook/client-side-table.js
@@ -3,10 +3,7 @@ import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 import { task, timeout } from 'ember-concurrency';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   query: '',
@@ -14,7 +11,9 @@ export default Component.extend(TableCommon, {
   // No need for `enableSync` here
   enableSync: false,
 
-  isLoading: computed.or('fetchRecords.isRunning', 'setRows.isRunning').readOnly(),
+  isLoading: computed
+    .or('fetchRecords.isRunning', 'setRows.isRunning')
+    .readOnly(),
 
   // Sort Logic
   sortedModel: computed.sort('model', 'sortBy').readOnly(),
@@ -29,34 +28,44 @@ export default Component.extend(TableCommon, {
   }).readOnly(),
 
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ];
   }),
 
   fetchRecords: task(function*() {
-    let records = yield this.get('store').query('user', { page: 1, limit: 100 });
+    let records = yield this.get('store').query('user', {
+      page: 1,
+      limit: 100
+    });
     this.get('model').setObjects(records.toArray());
     this.set('meta', records.get('meta'));
     yield this.get('filterAndSortModel').perform();
@@ -77,7 +86,7 @@ export default Component.extend(TableCommon, {
     let result = model;
 
     if (query !== '') {
-      result = model.filter((m) => {
+      result = model.filter(m => {
         return m.get(valuePath).toLowerCase().includes(query.toLowerCase());
       });
     }

--- a/tests/dummy/app/components/cookbook/custom-row-table.js
+++ b/tests/dummy/app/components/cookbook/custom-row-table.js
@@ -2,37 +2,41 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/cookbook/horizontal-scrolling-table.js
+++ b/tests/dummy/app/components/cookbook/horizontal-scrolling-table.js
@@ -2,40 +2,44 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '350px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '350px'
-    }, {
-      label: 'Address',
-      valuePath: 'address',
-      width: '350px'
-    }, {
-      label: 'State',
-      valuePath: 'state',
-      width: '350px'
-    }, {
-      label: 'Country',
-      valuePath: 'country',
-      width: '350px'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '350px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '350px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address',
+        width: '350px'
+      },
+      {
+        label: 'State',
+        valuePath: 'state',
+        width: '350px'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country',
+        width: '350px'
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/cookbook/paginated-table.js
+++ b/tests/dummy/app/components/cookbook/paginated-table.js
@@ -2,37 +2,41 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ];
   }),
 
   init() {

--- a/tests/dummy/app/components/cookbook/table-actions-table.js
+++ b/tests/dummy/app/components/cookbook/table-actions-table.js
@@ -2,47 +2,56 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }, {
-      label: 'Actions',
-      width: '100px',
-      sortable: false,
-      cellComponent: 'user-actions'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      },
+      {
+        label: 'Actions',
+        width: '100px',
+        sortable: false,
+        cellComponent: 'user-actions'
+      }
+    ];
   }),
 
   actions: {
     deleteUser(row) {
-      let confirmed = window.confirm(`Are you sure you want to delete ${row.get('firstName')} ${row.get('lastName')}?`);
+      let confirmed = window.confirm(
+        `Are you sure you want to delete ${row.get('firstName')} ${row.get(
+          'lastName'
+        )}?`
+      );
 
       if (confirmed) {
         this.get('table').removeRow(row);
@@ -51,7 +60,9 @@ export default Component.extend(TableCommon, {
     },
 
     notifyUser(row) {
-      window.alert(`${row.get('firstName')} ${row.get('lastName')} has been notified.`);
+      window.alert(
+        `${row.get('firstName')} ${row.get('lastName')} has been notified.`
+      );
     }
   }
 });

--- a/tests/dummy/app/components/responsive-table.js
+++ b/tests/dummy/app/components/responsive-table.js
@@ -2,46 +2,51 @@
 import Ember from 'ember';
 import TableCommon from '../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      width: '40px',
-      sortable: false,
-      cellComponent: 'row-toggle',
-      breakpoints: ['mobile', 'tablet', 'desktop']
-    }, {
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px',
-      breakpoints: ['tablet', 'desktop', 'jumbo']
-    }, {
-      label: 'Address',
-      valuePath: 'address',
-      breakpoints: ['tablet', 'desktop', 'jumbo']
-    }, {
-      label: 'State',
-      valuePath: 'state',
-      breakpoints: ['desktop', 'jumbo']
-    }, {
-      label: 'Country',
-      valuePath: 'country',
-      breakpoints: ['jumbo']
-    }];
+    return [
+      {
+        width: '40px',
+        sortable: false,
+        cellComponent: 'row-toggle',
+        breakpoints: ['mobile', 'tablet', 'desktop']
+      },
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px',
+        breakpoints: ['tablet', 'desktop', 'jumbo']
+      },
+      {
+        label: 'Address',
+        valuePath: 'address',
+        breakpoints: ['tablet', 'desktop', 'jumbo']
+      },
+      {
+        label: 'State',
+        valuePath: 'state',
+        breakpoints: ['desktop', 'jumbo']
+      },
+      {
+        label: 'Country',
+        valuePath: 'country',
+        breakpoints: ['jumbo']
+      }
+    ];
   }),
 
   actions: {

--- a/tests/dummy/app/components/rows/expandable-table.js
+++ b/tests/dummy/app/components/rows/expandable-table.js
@@ -2,20 +2,20 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'First Name',
-      valuePath: 'firstName'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName'
-    }];
+    return [
+      {
+        label: 'First Name',
+        valuePath: 'firstName'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName'
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/rows/selectable-table.js
+++ b/tests/dummy/app/components/rows/selectable-table.js
@@ -2,39 +2,43 @@
 import Ember from 'ember';
 import TableCommon from '../../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   hasSelection: computed.notEmpty('table.selectedRows'),
 
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ];
   }),
 
   actions: {

--- a/tests/dummy/app/components/scrolling-table.js
+++ b/tests/dummy/app/components/scrolling-table.js
@@ -2,10 +2,7 @@
 import Ember from 'ember';
 import TableCommon from '../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   currentScrollOffset: 0,
@@ -13,30 +10,37 @@ export default Component.extend(TableCommon, {
   scrollToRow: null,
 
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/simple-table.js
+++ b/tests/dummy/app/components/simple-table.js
@@ -2,37 +2,41 @@
 import Ember from 'ember';
 import TableCommon from '../mixins/table-common';
 
-const {
-  Component,
-  computed
-} = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend(TableCommon, {
   columns: computed(function() {
-    return [{
-      label: 'Avatar',
-      valuePath: 'avatar',
-      width: '60px',
-      sortable: false,
-      cellComponent: 'user-avatar'
-    }, {
-      label: 'First Name',
-      valuePath: 'firstName',
-      width: '150px'
-    }, {
-      label: 'Last Name',
-      valuePath: 'lastName',
-      width: '150px'
-    }, {
-      label: 'Address',
-      valuePath: 'address'
-    }, {
-      label: 'State',
-      valuePath: 'state'
-    }, {
-      label: 'Country',
-      valuePath: 'country'
-    }];
+    return [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First Name',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last Name',
+        valuePath: 'lastName',
+        width: '150px'
+      },
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ];
   })
 });
 // END-SNIPPET

--- a/tests/dummy/app/mixins/table-common.js
+++ b/tests/dummy/app/mixins/table-common.js
@@ -3,15 +3,10 @@ import Ember from 'ember';
 import Table from 'ember-light-table';
 import { task } from 'ember-concurrency';
 
-const {
-  inject,
-  isEmpty,
-  computed,
-  Mixin
-} = Ember;
+const { inject: { service }, isEmpty, computed, Mixin } = Ember;
 
 export default Mixin.create({
-  store: inject.service(),
+  store: service(),
 
   page: 0,
   limit: 10,
@@ -30,8 +25,12 @@ export default Mixin.create({
   init() {
     this._super(...arguments);
 
-    let table = new Table(this.get('columns'), this.get('model'), { enableSync: this.get('enableSync') });
-    let sortColumn = table.get('allColumns').findBy('valuePath', this.get('sort'));
+    let table = new Table(this.get('columns'), this.get('model'), {
+      enableSync: this.get('enableSync')
+    });
+    let sortColumn = table
+      .get('allColumns')
+      .findBy('valuePath', this.get('sort'));
 
     // Setup initial sort column
     if (sortColumn) {
@@ -42,7 +41,10 @@ export default Mixin.create({
   },
 
   fetchRecords: task(function*() {
-    let records = yield this.get('store').query('user', this.getProperties(['page', 'limit', 'sort', 'dir']));
+    let records = yield this.get('store').query(
+      'user',
+      this.getProperties(['page', 'limit', 'sort', 'dir'])
+    );
     this.get('model').pushObjects(records.toArray());
     this.set('meta', records.get('meta'));
     this.set('canLoadMore', !isEmpty(records));

--- a/tests/dummy/app/routes/table-route.js
+++ b/tests/dummy/app/routes/table-route.js
@@ -1,9 +1,6 @@
 import Ember from 'ember';
 
-const {
-  A,
-  Route
-} = Ember;
+const { A, Route } = Ember;
 
 export default Route.extend({
   model() {

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,12 +1,9 @@
 import Ember from 'ember';
 import ENV from '../config/environment';
 
-const {
-  A: emberArray
-} = Ember;
+const { A: emberArray } = Ember;
 
 export default function() {
-
   // These comments are here to help you get started. Feel free to delete them.
 
   this.passthrough('/write-coverage');

--- a/tests/dummy/mirage/factories/user.js
+++ b/tests/dummy/mirage/factories/user.js
@@ -7,7 +7,17 @@ import Mirage, { faker } from 'ember-cli-mirage';
 
 faker.locale = 'en_US';
 
-const MATERIAL_UI_COLORS = ['#F44336', '#E91E63', '#9C27B0', '#009688', '#2196F3', '#4CAF50', '#FFC107', '#FF5722', '#607D8B'];
+const MATERIAL_UI_COLORS = [
+  '#F44336',
+  '#E91E63',
+  '#9C27B0',
+  '#009688',
+  '#2196F3',
+  '#4CAF50',
+  '#FFC107',
+  '#FF5722',
+  '#607D8B'
+];
 
 export default Mirage.Factory.extend({
   firstName: faker.name.firstName,

--- a/tests/dummy/mirage/models/user.js
+++ b/tests/dummy/mirage/models/user.js
@@ -1,4 +1,3 @@
 import { Model } from 'ember-cli-mirage';
 
-export default Model.extend({
-});
+export default Model.extend({});

--- a/tests/dummy/mirage/scenarios/default.js
+++ b/tests/dummy/mirage/scenarios/default.js
@@ -1,5 +1,4 @@
 export default function(server) {
-
   // Seed your development database using your factories. This
   // data will not be loaded in your tests.
 

--- a/tests/helpers/has-class.js
+++ b/tests/helpers/has-class.js
@@ -1,4 +1,5 @@
-
 export default function hasClass(elem, cls) {
-  return [...elem.classList].filter((cssClass) => cssClass === cls).reduce((bool, next) => bool || next, false);
+  return [...elem.classList]
+    .filter(cssClass => cssClass === cls)
+    .reduce((bool, next) => bool || next, false);
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { module } from 'qunit';
 import Ember from 'ember';
 import startApp from '../helpers/start-app';

--- a/tests/helpers/responsive.js
+++ b/tests/helpers/responsive.js
@@ -2,10 +2,7 @@
 import Ember from 'ember';
 import MediaService from 'ember-responsive/media';
 
-const {
-  getOwner
-} = Ember;
-const { classify } = Ember.String;
+const { getOwner, String: { classify } } = Ember;
 
 MediaService.reopen({
   // Change this if you want a different default breakpoint in tests.
@@ -46,7 +43,10 @@ MediaService.reopen({
   }
 });
 
-export default Ember.Test.registerAsyncHelper('setBreakpoint', function(app, breakpoint) {
+export default Ember.Test.registerAsyncHelper('setBreakpoint', function(
+  app,
+  breakpoint
+) {
   // this should use getOwner once that's supported
   const mediaService = app.__deprecatedInstance__.lookup('service:media');
   mediaService._forceSetBreakpoint(breakpoint);

--- a/tests/helpers/table-columns.js
+++ b/tests/helpers/table-columns.js
@@ -1,59 +1,77 @@
-export default [{
-  label: 'Avatar',
-  valuePath: 'avatar',
-  width: '60px',
-  sortable: false,
-  cellComponent: 'user-avatar'
-}, {
-  label: 'First Name',
-  valuePath: 'firstName',
-  width: '150px'
-}, {
-  label: 'Last Name',
-  valuePath: 'lastName',
-  width: '150px'
-}, {
-  label: 'Address',
-  valuePath: 'address'
-}, {
-  label: 'State',
-  valuePath: 'state'
-}, {
-  label: 'Country',
-  valuePath: 'country'
-}];
-
-export const GroupedColumns = [{
-  label: 'User Details',
-  sortable: false,
-  align: 'center',
-  subColumns: [{
+export default [
+  {
     label: 'Avatar',
     valuePath: 'avatar',
     width: '60px',
     sortable: false,
     cellComponent: 'user-avatar'
-  }, {
-    label: 'First',
+  },
+  {
+    label: 'First Name',
     valuePath: 'firstName',
     width: '150px'
-  }, {
-    label: 'Last',
+  },
+  {
+    label: 'Last Name',
     valuePath: 'lastName',
     width: '150px'
-  }]
-}, {
-  label: 'Contact Information',
-  sortable: false,
-  align: 'center',
-  subColumns: [{
+  },
+  {
     label: 'Address',
     valuePath: 'address'
-  }, {
+  },
+  {
     label: 'State',
     valuePath: 'state'
-  }, {
+  },
+  {
     label: 'Country',
     valuePath: 'country'
-  }]
-}];
+  }
+];
+
+export const GroupedColumns = [
+  {
+    label: 'User Details',
+    sortable: false,
+    align: 'center',
+    subColumns: [
+      {
+        label: 'Avatar',
+        valuePath: 'avatar',
+        width: '60px',
+        sortable: false,
+        cellComponent: 'user-avatar'
+      },
+      {
+        label: 'First',
+        valuePath: 'firstName',
+        width: '150px'
+      },
+      {
+        label: 'Last',
+        valuePath: 'lastName',
+        width: '150px'
+      }
+    ]
+  },
+  {
+    label: 'Contact Information',
+    sortable: false,
+    align: 'center',
+    subColumns: [
+      {
+        label: 'Address',
+        valuePath: 'address'
+      },
+      {
+        label: 'State',
+        valuePath: 'state'
+      },
+      {
+        label: 'Country',
+        valuePath: 'country'
+      }
+    ]
+  }
+];

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -2,7 +2,9 @@ import { findAll, find, scrollTo } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import { skip } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
-import startMirage, { createUsers } from '../../helpers/setup-mirage-for-integration';
+import startMirage, {
+  createUsers
+} from '../../helpers/setup-mirage-for-integration';
 import Table from 'ember-light-table';
 import Columns from '../../helpers/table-columns';
 import hasClass from '../../helpers/has-class';
@@ -19,7 +21,7 @@ moduleForComponent('light-table', 'Integration | Component | light table', {
 
 test('it renders', function(assert) {
   this.set('table', new Table());
-  this.render(hbs `{{light-table table}}`);
+  this.render(hbs`{{light-table table}}`);
 
   assert.equal(find('*').textContent.trim(), '');
 });
@@ -34,7 +36,7 @@ skip('scrolled to bottom', async function(assert) {
     assert.ok(true);
   });
 
-  this.render(hbs `
+  this.render(hbs`
     {{#light-table table height='40vh' as |t|}}
       {{t.head}}
       {{t.body onScrolledToBottom=(action 'onScrolledToBottom')}}
@@ -46,7 +48,10 @@ skip('scrolled to bottom', async function(assert) {
   let scrollContainer = '.tse-scroll-content';
   let { scrollHeight } = find(scrollContainer);
 
-  assert.ok(findAll(scrollContainer).length > 0, 'scroll container was rendered');
+  assert.ok(
+    findAll(scrollContainer).length > 0,
+    'scroll container was rendered'
+  );
   assert.equal(scrollHeight, 2500, 'scroll height is 2500');
 
   await scrollTo(scrollContainer, 0, scrollHeight);
@@ -57,7 +62,7 @@ test('fixed header', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
   this.set('fixed', true);
 
-  this.render(hbs `
+  this.render(hbs`
     {{#light-table table height='500px' id='lightTable' as |t|}}
       {{t.head fixed=fixed}}
       {{t.body}}
@@ -76,7 +81,7 @@ test('fixed footer', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
   this.set('fixed', true);
 
-  this.render(hbs `
+  this.render(hbs`
     {{#light-table table height='500px' id='lightTable' as |t|}}
       {{t.body}}
       {{t.foot fixed=fixed}}
@@ -92,12 +97,11 @@ test('fixed footer', function(assert) {
 
 // TODO: Passes in Chrome but not in Phantom
 skip('table assumes height of container', function(assert) {
-
   assert.expect(1);
   this.set('table', new Table(Columns, createUsers(5)));
   this.set('fixed', true);
 
-  this.render(hbs `
+  this.render(hbs`
     <div style="height: 500px">
       {{#light-table table id='lightTable' as |t|}}
         {{t.body}}
@@ -107,17 +111,18 @@ skip('table assumes height of container', function(assert) {
   `);
 
   assert.equal(find('#lightTable').offsetHeight, 500, 'table is 500px height');
-
 });
 
 // TODO: figure out why this test doesn't work properly in Phantomjs
-skip('table body should consume all available space when not enough content to fill it', function(assert) {
-  assert.expect(3);
+skip(
+  'table body should consume all available space when not enough content to fill it',
+  function(assert) {
+    assert.expect(3);
 
-  this.set('table', new Table(Columns, createUsers(1)));
-  this.set('fixed', true);
+    this.set('table', new Table(Columns, createUsers(1)));
+    this.set('fixed', true);
 
-  this.render(hbs `
+    this.render(hbs`
     <div style="height: 500px">
       {{#light-table table id='lightTable' as |t|}}
         {{t.head fixed=true}}
@@ -128,41 +133,47 @@ skip('table body should consume all available space when not enough content to f
       {{/light-table}}
     </div>
   `);
-  assert.equal(find('.lt-head-wrap').offsetHeight, 42, 'header is 42px tall');
-  assert.equal(find('.lt-body-wrap').offsetHeight, 438, 'body is 438px tall');
-  assert.equal(find('.lt-foot-wrap').offsetHeight, 20, 'header is 20px tall');
-
-});
+    assert.equal(find('.lt-head-wrap').offsetHeight, 42, 'header is 42px tall');
+    assert.equal(find('.lt-body-wrap').offsetHeight, 438, 'body is 438px tall');
+    assert.equal(find('.lt-foot-wrap').offsetHeight, 20, 'header is 20px tall');
+  }
+);
 
 test('accepts components that are used in the body', function(assert) {
-
   register(this, 'component:custom-row', RowComponent);
 
   this.set('table', new Table(Columns, createUsers(1)));
 
-  this.render(hbs `
+  this.render(hbs`
     {{#light-table table as |t|}}
       {{t.body rowComponent=(component "custom-row" classNames="custom-row")}}
     {{/light-table}}
   `);
 
-  assert.equal(findAll('.lt-row.custom-row').length, 1, 'row has custom-row class');
+  assert.equal(
+    findAll('.lt-row.custom-row').length,
+    1,
+    'row has custom-row class'
+  );
 });
 
 test('passed in components can have computed properties', function(assert) {
-
-  register(this, 'component:custom-row', RowComponent.extend({
-    classNameBindings: ['isActive'],
-    current: null,
-    isActive: Ember.computed('row.content', 'current', function() {
-      return this.get('row.content') === this.get('current');
+  register(
+    this,
+    'component:custom-row',
+    RowComponent.extend({
+      classNameBindings: ['isActive'],
+      current: null,
+      isActive: Ember.computed('row.content', 'current', function() {
+        return this.get('row.content') === this.get('current');
+      })
     })
-  }));
+  );
 
   let users = createUsers(3);
   this.set('table', new Table(Columns, users));
 
-  this.render(hbs `
+  this.render(hbs`
     {{#light-table table as |t|}}
       {{t.body
         rowComponent=(component "custom-row" classNames="custom-row" current=current)
@@ -170,7 +181,11 @@ test('passed in components can have computed properties', function(assert) {
     {{/light-table}}
   `);
 
-  assert.equal(findAll('.custom-row').length, 3, 'three custom rows were rendered');
+  assert.equal(
+    findAll('.custom-row').length,
+    3,
+    'three custom rows were rendered'
+  );
   assert.notOk(find('.custom-row.is-active'), 'none of the items are active');
 
   this.set('current', users[0]);
@@ -198,7 +213,7 @@ test('onScroll', async function(assert) {
     }
   });
 
-  this.render(hbs `
+  this.render(hbs`
     {{#light-table table height='40vh' as |t|}}
       {{t.head fixed=true}}
       {{t.body

--- a/tests/integration/components/light-table/cells/base-test.js
+++ b/tests/integration/components/light-table/cells/base-test.js
@@ -4,9 +4,13 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { Row, Column } from 'ember-light-table';
 
-moduleForComponent('light-table/cells/base', 'Integration | Component | Cells | base', {
-  integration: true
-});
+moduleForComponent(
+  'light-table/cells/base',
+  'Integration | Component | Cells | base',
+  {
+    integration: true
+  }
+);
 
 test('it renders', function(assert) {
   this.set('column', new Column());
@@ -16,12 +20,15 @@ test('it renders', function(assert) {
 });
 
 test('cell with column format', function(assert) {
-  this.set('column', new Column({
-    valuePath: 'num',
-    format(value) {
-      return value * 2;
-    }
-  }));
+  this.set(
+    'column',
+    new Column({
+      valuePath: 'num',
+      format(value) {
+        return value * 2;
+      }
+    })
+  );
 
   this.set('row', new Row());
 
@@ -31,15 +38,21 @@ test('cell with column format', function(assert) {
 });
 
 test('cell format with no valuePath', function(assert) {
-  this.set('column', new Column({
-    format() {
-      return this.get('row.num') * 2;
-    }
-  }));
+  this.set(
+    'column',
+    new Column({
+      format() {
+        return this.get('row.num') * 2;
+      }
+    })
+  );
 
-  this.set('row', new Row({
-    num: 2
-  }));
+  this.set(
+    'row',
+    new Row({
+      num: 2
+    })
+  );
 
   this.render(hbs`{{light-table/cells/base column row}}`);
 
@@ -47,22 +60,30 @@ test('cell format with no valuePath', function(assert) {
 });
 
 test('cell with nested valuePath', function(assert) {
-  this.set('column', new Column({
-    valuePath: 'foo.bar.baz',
-    format(value) {
-      return value * 2;
-    }
-  }));
-
-  this.set('row', new Row({
-    foo: {
-      bar: {
-        baz: 2
+  this.set(
+    'column',
+    new Column({
+      valuePath: 'foo.bar.baz',
+      format(value) {
+        return value * 2;
       }
-    }
-  }));
+    })
+  );
 
-  this.render(hbs`{{light-table/cells/base column row rawValue=(get row column.valuePath)}}`);
+  this.set(
+    'row',
+    new Row({
+      foo: {
+        bar: {
+          baz: 2
+        }
+      }
+    })
+  );
+
+  this.render(
+    hbs`{{light-table/cells/base column row rawValue=(get row column.valuePath)}}`
+  );
 
   assert.equal(find('*').textContent.trim(), '4');
 

--- a/tests/integration/components/light-table/columns/base-test.js
+++ b/tests/integration/components/light-table/columns/base-test.js
@@ -3,9 +3,13 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { Column } from 'ember-light-table';
 
-moduleForComponent('light-table/columns/base', 'Integration | Component | Columns | base', {
-  integration: true
-});
+moduleForComponent(
+  'light-table/columns/base',
+  'Integration | Component | Columns | base',
+  {
+    integration: true
+  }
+);
 
 test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/lt-body-test.js
+++ b/tests/integration/components/lt-body-test.js
@@ -2,14 +2,14 @@ import { click, findAll, find, triggerEvent } from 'ember-native-dom-helpers';
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import startMirage, { createUsers } from '../../helpers/setup-mirage-for-integration';
+import startMirage, {
+  createUsers
+} from '../../helpers/setup-mirage-for-integration';
 import Table from 'ember-light-table';
 import hasClass from '../../helpers/has-class';
 import Columns from '../../helpers/table-columns';
 
-const {
-  run
-} = Ember;
+const { run } = Ember;
 
 moduleForComponent('lt-body', 'Integration | Component | lt body', {
   integration: true,
@@ -24,7 +24,7 @@ moduleForComponent('lt-body', 'Integration | Component | lt body', {
 });
 
 test('it renders', function(assert) {
-  this.render(hbs `{{lt-body sharedOptions=sharedOptions}}`);
+  this.render(hbs`{{lt-body sharedOptions=sharedOptions}}`);
   assert.equal(find('*').textContent.trim(), '');
 });
 
@@ -32,7 +32,9 @@ test('row selection - enable or disable', function(assert) {
   this.set('table', new Table(Columns, createUsers(1)));
   this.set('canSelect', false);
 
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect}}`);
+  this.render(
+    hbs`{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect}}`
+  );
 
   let row = find('tr');
 
@@ -52,7 +54,9 @@ test('row selection - enable or disable', function(assert) {
 test('row selection - ctrl-click to modify selection', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
 
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true}}`);
+  this.render(
+    hbs`{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true}}`
+  );
   let firstRow = find('tr:first-child');
   let middleRow = find('tr:nth-child(4)');
   let lastRow = find('tr:last-child');
@@ -60,22 +64,40 @@ test('row selection - ctrl-click to modify selection', function(assert) {
   assert.equal(findAll('tbody > tr').length, 5);
 
   click(firstRow);
-  assert.equal(findAll('tr.is-selected').length, 1, 'clicking a row selects it');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    1,
+    'clicking a row selects it'
+  );
 
   click(lastRow, { shiftKey: true });
-  assert.equal(findAll('tr.is-selected').length, 5, 'shift-clicking another row selects it and all rows between');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    5,
+    'shift-clicking another row selects it and all rows between'
+  );
 
   click(middleRow, { ctrlKey: true });
-  assert.equal(findAll('tr.is-selected').length, 4, 'ctrl-clicking a selected row deselects it');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    4,
+    'ctrl-clicking a selected row deselects it'
+  );
 
   click(firstRow);
-  assert.equal(findAll('tr.is-selected').length, 0, 'clicking a selected row deselects all rows');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    0,
+    'clicking a selected row deselects all rows'
+  );
 });
 
 test('row selection - click to modify selection', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
 
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true multiSelectRequiresKeyboard=false}}`);
+  this.render(
+    hbs`{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true multiSelectRequiresKeyboard=false}}`
+  );
 
   let firstRow = find('tr:first-child');
   let middleRow = find('tr:nth-child(4)');
@@ -84,23 +106,39 @@ test('row selection - click to modify selection', function(assert) {
   assert.equal(findAll('tbody > tr').length, 5);
 
   click(firstRow);
-  assert.equal(findAll('tr.is-selected').length, 1, 'clicking a row selects it');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    1,
+    'clicking a row selects it'
+  );
 
   click(lastRow, { shiftKey: true });
-  assert.equal(findAll('tr.is-selected').length, 5, 'shift-clicking another row selects it and all rows between');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    5,
+    'shift-clicking another row selects it and all rows between'
+  );
 
   click(middleRow);
-  assert.equal(findAll('tr.is-selected').length, 4, 'clicking a selected row deselects it without affecting other selected rows');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    4,
+    'clicking a selected row deselects it without affecting other selected rows'
+  );
 
   click(middleRow);
-  assert.equal(findAll('tr.is-selected').length, 5, 'clicking a deselected row selects it without affecting other selected rows');
+  assert.equal(
+    findAll('tr.is-selected').length,
+    5,
+    'clicking a deselected row selects it without affecting other selected rows'
+  );
 });
 
 test('row expansion', function(assert) {
   this.set('table', new Table(Columns, createUsers(2)));
   this.set('canExpand', false);
 
-  this.render(hbs `
+  this.render(hbs`
     {{#lt-body table=table sharedOptions=sharedOptions canSelect=false canExpand=canExpand multiRowExpansion=false as |b|}}
       {{#b.expanded-row}} Hello {{/b.expanded-row}}
     {{/lt-body}}
@@ -133,7 +171,7 @@ test('row expansion', function(assert) {
 
 test('row expansion - multiple', function(assert) {
   this.set('table', new Table(Columns, createUsers(2)));
-  this.render(hbs `
+  this.render(hbs`
     {{#lt-body table=table sharedOptions=sharedOptions canExpand=true as |b|}}
       {{#b.expanded-row}} Hello {{/b.expanded-row}}
     {{/lt-body}}
@@ -142,7 +180,7 @@ test('row expansion - multiple', function(assert) {
   let rows = findAll('tr');
   assert.equal(rows.length, 2);
 
-  rows.forEach((row) => {
+  rows.forEach(row => {
     assert.ok(hasClass(row, 'is-expandable'));
     click(row);
     assert.equal(row.nextElementSibling.textContent.trim(), 'Hello');
@@ -155,9 +193,11 @@ test('row actions', function(assert) {
   assert.expect(2);
 
   this.set('table', new Table(Columns, createUsers(1)));
-  this.on('onRowClick', (row) => assert.ok(row));
-  this.on('onRowDoubleClick', (row) => assert.ok(row));
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions onRowClick=(action 'onRowClick') onRowDoubleClick=(action 'onRowDoubleClick')}}`);
+  this.on('onRowClick', row => assert.ok(row));
+  this.on('onRowDoubleClick', row => assert.ok(row));
+  this.render(
+    hbs`{{lt-body table=table sharedOptions=sharedOptions onRowClick=(action 'onRowClick') onRowDoubleClick=(action 'onRowDoubleClick')}}`
+  );
 
   let row = find('tr');
   click(row);
@@ -167,7 +207,7 @@ test('row actions', function(assert) {
 test('hidden rows', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
 
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions}}`);
+  this.render(hbs`{{lt-body table=table sharedOptions=sharedOptions}}`);
 
   assert.equal(findAll('tbody > tr').length, 5);
 
@@ -189,15 +229,26 @@ test('scaffolding', function(assert) {
   const users = createUsers(1);
   this.set('table', new Table(Columns, users));
 
-  this.render(hbs `{{lt-body table=table sharedOptions=sharedOptions enableScaffolding=true}}`);
+  this.render(
+    hbs`{{lt-body table=table sharedOptions=sharedOptions enableScaffolding=true}}`
+  );
 
   const [scaffoldingRow, userRow] = findAll('tr');
   const userCells = findAll('.lt-cell', userRow);
 
-  assert.ok(hasClass(scaffoldingRow, 'lt-scaffolding-row'), 'the first row of the <tbody> is a scaffolding row');
-  assert.notOk(hasClass(userRow, 'lt-scaffolding-row'), 'the second row of the <tbody> is not a scaffolding row');
+  assert.ok(
+    hasClass(scaffoldingRow, 'lt-scaffolding-row'),
+    'the first row of the <tbody> is a scaffolding row'
+  );
+  assert.notOk(
+    hasClass(userRow, 'lt-scaffolding-row'),
+    'the second row of the <tbody> is not a scaffolding row'
+  );
 
-  assert.notOk(userRow.hasAttribute('style'), 'the second row of the <tbody> has no `style` attribute');
+  assert.notOk(
+    userRow.hasAttribute('style'),
+    'the second row of the <tbody> has no `style` attribute'
+  );
 
   assert.ok(
     Columns.map((c, i) => {
@@ -212,7 +263,7 @@ test('scaffolding', function(assert) {
 test('overwrite', function(assert) {
   this.set('table', new Table(Columns, createUsers(5)));
 
-  this.render(hbs `
+  this.render(hbs`
     {{#lt-body table=table sharedOptions=sharedOptions overwrite=true as |columns rows|}}
       {{columns.length}}, {{rows.length}}
     {{/lt-body}}

--- a/tests/integration/components/lt-column-resizer-test.js
+++ b/tests/integration/components/lt-column-resizer-test.js
@@ -2,9 +2,13 @@ import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('lt-column-resizer', 'Integration | Component | lt column resizer', {
-  integration: true
-});
+moduleForComponent(
+  'lt-column-resizer',
+  'Integration | Component | lt column resizer',
+  {
+    integration: true
+  }
+);
 
 test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/lt-head-test.js
+++ b/tests/integration/components/lt-head-test.js
@@ -29,13 +29,15 @@ test('render grouped columns', function(assert) {
 
 test('click - non-sortable column', function(assert) {
   this.set('table', new Table(Columns));
-  this.on('onColumnClick', (column) => {
+  this.on('onColumnClick', column => {
     assert.ok(column);
     assert.notOk(column.sortable);
     assert.equal(column.label, 'Avatar');
   });
 
-  this.render(hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`);
+  this.render(
+    hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`
+  );
 
   assert.equal(findAll('tr > th').length, 6);
   let nonSortableHeader = find('tr > th');
@@ -45,7 +47,7 @@ test('click - non-sortable column', function(assert) {
 test('click - sortable column', function(assert) {
   this.set('table', new Table(Columns));
   let asc = true;
-  this.on('onColumnClick', (column) => {
+  this.on('onColumnClick', column => {
     assert.ok(column);
     assert.ok(column.sortable);
     assert.ok(column.sorted);
@@ -53,7 +55,9 @@ test('click - sortable column', function(assert) {
     assert.equal(column.ascending, asc);
   });
 
-  this.render(hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`);
+  this.render(
+    hbs`{{lt-head table=table renderInPlace=true onColumnClick=(action 'onColumnClick')}}`
+  );
   let allHeaders = findAll('tr > th');
   let sortableHeader = allHeaders[allHeaders.length - 1];
   assert.equal(findAll('tr > th').length, 6);
@@ -64,13 +68,15 @@ test('click - sortable column', function(assert) {
 
 test('double click', function(assert) {
   this.set('table', new Table(Columns));
-  this.on('onColumnDoubleClick', (column) => {
+  this.on('onColumnDoubleClick', column => {
     assert.ok(column);
     assert.notOk(column.sortable);
     assert.equal(column.label, 'Avatar');
   });
 
-  this.render(hbs`{{lt-head table=table renderInPlace=true onColumnDoubleClick=(action 'onColumnDoubleClick')}}`);
+  this.render(
+    hbs`{{lt-head table=table renderInPlace=true onColumnDoubleClick=(action 'onColumnDoubleClick')}}`
+  );
   let allHeaders = findAll('tr > th');
   let sortableHeader = allHeaders[allHeaders.length - 1];
 

--- a/tests/integration/components/lt-spanned-row-test.js
+++ b/tests/integration/components/lt-spanned-row-test.js
@@ -2,9 +2,13 @@ import { find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('lt-spanned-row', 'Integration | Component | lt spanned row', {
-  integration: true
-});
+moduleForComponent(
+  'lt-spanned-row',
+  'Integration | Component | lt spanned row',
+  {
+    integration: true
+  }
+);
 
 test('it renders', function(assert) {
   this.render(hbs`{{lt-spanned-row}}`);
@@ -44,7 +48,6 @@ test('colspan', function(assert) {
 });
 
 test('yield', function(assert) {
-
   this.render(hbs`
     {{#lt-spanned-row yield=(hash name="Offir") as |row|}}
       {{row.name}}

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,5 @@
 import resolver from './helpers/resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import { setResolver } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);

--- a/tests/unit/classes/column-test.js
+++ b/tests/unit/classes/column-test.js
@@ -31,7 +31,11 @@ test('create column - column instance', function(assert) {
 
 test('reopen colum', function(assert) {
   assert.equal(typeof Column.reopen, 'function', 'reopen is a function');
-  assert.equal(typeof Column.reopenClass, 'function', 'reopenClass is a function');
+  assert.equal(
+    typeof Column.reopenClass,
+    'function',
+    'reopenClass is a function'
+  );
 });
 
 test('CP - isGroupColumn', function(assert) {
@@ -86,5 +90,4 @@ test('subColumns / parent', function(assert) {
   assert.equal(col.subColumns.length, 1);
 
   assert.equal(col.subColumns[0].get('parent'), col);
-
 });

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -2,9 +2,7 @@ import Ember from 'ember';
 import { Table, Column, Row } from 'ember-light-table';
 import { module, test } from 'qunit';
 
-const {
-  A: emberArray
-} = Ember;
+const { A: emberArray } = Ember;
 
 module('Unit | Classes | Table');
 
@@ -29,7 +27,11 @@ test('create table - with options', function(assert) {
 
 test('reopen table', function(assert) {
   assert.equal(typeof Table.reopen, 'function', 'reopen is a function');
-  assert.equal(typeof Table.reopenClass, 'function', 'reopenClass is a function');
+  assert.equal(
+    typeof Table.reopenClass,
+    'function',
+    'reopenClass is a function'
+  );
 });
 
 test('CP - visibleColumnGroups', function(assert) {
@@ -85,9 +87,15 @@ test('CP - isEmpty', function(assert) {
   assert.ok(table, 'table is set up correctly');
   assert.ok(table.get('isEmpty'), 'table is initially empty');
   table.pushRow({});
-  assert.notOk(table.get('isEmpty'), 'table is not empty after a row was pushed');
+  assert.notOk(
+    table.get('isEmpty'),
+    'table is not empty after a row was pushed'
+  );
   table.setRows([]);
-  assert.ok(table.get('isEmpty'), 'table is empty again after the rows were cleared');
+  assert.ok(
+    table.get('isEmpty'),
+    'table is empty again after the rows were cleared'
+  );
 });
 
 test('CP - isEmpty (enableSync = true)', function(assert) {
@@ -97,9 +105,15 @@ test('CP - isEmpty (enableSync = true)', function(assert) {
   assert.ok(table, 'table is set up correctly');
   assert.ok(table.get('isEmpty'), 'table is initially empty');
   rowsArray.pushObject({});
-  assert.notOk(table.get('isEmpty'), 'table is not empty after a row was pushed');
+  assert.notOk(
+    table.get('isEmpty'),
+    'table is not empty after a row was pushed'
+  );
   rowsArray.clear();
-  assert.ok(table.get('isEmpty'), 'table is empty again after the rows were cleared');
+  assert.ok(
+    table.get('isEmpty'),
+    'table is empty again after the rows were cleared'
+  );
 });
 
 test('table method - setRows', function(assert) {
@@ -453,7 +467,10 @@ test('table modifications with sync enabled - simple', function(assert) {
   assert.equal(rows.get('length'), 2);
   assert.equal(table.get('rows.length'), rows.get('length'));
 
-  assert.deepEqual(table.get('rows').getEach('firstName'), rows.getEach('firstName'));
+  assert.deepEqual(
+    table.get('rows').getEach('firstName'),
+    rows.getEach('firstName')
+  );
 
   table.get('rows').clear();
 
@@ -470,28 +487,40 @@ test('table modifications with sync enabled - stress', function(assert) {
   }
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 
   for (let i = 100; i < 200; i++) {
     rows.pushObject({ position: i });
   }
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 
   table.removeRowAt(5);
   table.removeRowAt(10);
   table.removeRowAt(125);
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 
   rows.removeAt(10);
   rows.removeAt(20);
   rows.removeAt(150);
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 
   table.get('rows').clear();
 
@@ -509,7 +538,10 @@ test('table modifications with sync enabled - sort', function(assert) {
   }
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 
   rows.sort((a, b) => {
     return a.position > b.position ? -1 : 1;
@@ -518,12 +550,18 @@ test('table modifications with sync enabled - sort', function(assert) {
   rows.arrayContentDidChange(0, length, length);
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 
   rows.reverseObjects();
 
   assert.equal(table.get('rows.length'), rows.get('length'));
-  assert.deepEqual(table.get('rows').getEach('position'), rows.getEach('position'));
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    rows.getEach('position')
+  );
 });
 
 test('setRowsSynced', function(assert) {
@@ -536,16 +574,32 @@ test('setRowsSynced', function(assert) {
   for (let i = 0; i < initialLength; i++) {
     initialRows.pushObject({ position: i });
   }
-  assert.deepEqual(table.get('rows').getEach('position'), initialRows.getEach('position'), 'the table is initialized with a synced array');
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    initialRows.getEach('position'),
+    'the table is initialized with a synced array'
+  );
 
   table.setRowsSynced(otherRows);
-  assert.deepEqual(table.get('rows').getEach('position'), otherRows.getEach('position'), 'the synced array may be replaced');
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    otherRows.getEach('position'),
+    'the synced array may be replaced'
+  );
 
   for (let i = 0; i < otherLength; i++) {
     otherRows.pushObject({ position: i });
   }
-  assert.deepEqual(table.get('rows').getEach('position'), otherRows.getEach('position'), 'the replacement array is correctly synced');
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    otherRows.getEach('position'),
+    'the replacement array is correctly synced'
+  );
 
   initialRows.popObject();
-  assert.deepEqual(table.get('rows').getEach('position'), otherRows.getEach('position'), 'mutating the replaced array has no effect');
+  assert.deepEqual(
+    table.get('rows').getEach('position'),
+    otherRows.getEach('position'),
+    'mutating the replaced array has no effect'
+  );
 });

--- a/tests/unit/utils/fix-proto-test.js
+++ b/tests/unit/utils/fix-proto-test.js
@@ -2,9 +2,7 @@ import Ember from 'ember';
 import fixProto from 'ember-light-table/utils/fix-proto';
 import { module, test } from 'qunit';
 
-const {
-  Object: EmberObject
-} = Ember;
+const { Object: EmberObject } = Ember;
 
 module('Unit | Utility | fix proto');
 
@@ -13,7 +11,9 @@ module('Unit | Utility | fix proto');
  * make any sense. The only relevent environments are IE <= 10.
  */
 
-test('ES6 classes that extend `Ember.Object` can be reopened after `fixProto` was used on them', function(assert) {
+test('ES6 classes that extend `Ember.Object` can be reopened after `fixProto` was used on them', function(
+  assert
+) {
   class DerivedClass extends EmberObject.extend() {}
 
   fixProto(DerivedClass);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,11 +3401,24 @@ escope@~0.0.13:
   dependencies:
     estraverse ">= 0.0.2"
 
+eslint-config-prettier@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz#b75b1eabea0c8b97b34403647ee25db349b9d8a0"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-plugin-ember-suave@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz#ea7d232a126562dcd8b1ee3aa2700ac3b626e514"
   dependencies:
     requireindex "~1.1.0"
+
+eslint-plugin-prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.2.tgz#4b90f4ee7f92bfbe2e926017e1ca40eb628965ea"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^20.0.1"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -3680,6 +3693,10 @@ fake-xml-http-request@^1.4.0:
 faker@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/faker/-/faker-3.1.0.tgz#0f908faf4e6ec02524e54a57e432c5c013e08c9f"
+
+fast-diff@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -4025,6 +4042,10 @@ get-caller-file@^1.0.0:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -4768,6 +4789,10 @@ istextorbinary@2.1.0:
     binaryextensions "1 || 2"
     editions "^1.1.1"
     textextensions "1 || 2"
+
+jest-docblock@^20.0.1:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
 jju@^1.1.0:
   version "1.3.0"
@@ -6175,6 +6200,10 @@ pretender@^1.4.2:
   dependencies:
     fake-xml-http-request "^1.4.0"
     route-recognizer "^0.2.3"
+
+prettier@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
 
 printf@^0.2.3:
   version "0.2.5"


### PR DESCRIPTION
This PR adds the [Prettier](https://prettier.io/) code auto formatter as a fixable eslint rule.

This means that a uniform coding style will be enforced by linter rules. If you violate the coding style, ember-cli will scream warnings. You can also configure your editor to fix eslint errors on save, which I highly recommend. Doing so will ensure that your code is automatically formatted.

I disabled Prettier for some bits, as that could cause pain when upgrading ember-cli.

We adopted Prettier at work and I think it greatly improved our developer experience. 99 % the time it generates easier to read code. For the other 1% there's [`// prettier-ignore`](https://prettier.io/docs/en/usage.html#excluding-code-from-formatting) or `/* eslint-disable prettier/prettier */`.

I have no hard feelings, if you're against merging.