### PR TITLE
[FEATURE occlusion]: Preliminary Vertical collection integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A lightweight contextual component based table addon that follows Ember's action
 - Easy table manipulation
 - Easy override to table header, body, and footer
 - Contextual component for header, body, and footer, as well as loading, no data, and expanded row
+- **EXPERIMENTAL** Occlusion rendering leveraging [vertical-collection](https://github.com/html-next/vertical-collection). See [Demo](http://offirgolan.github.io/ember-light-table/#/cookbook/occlusion-rendering).
 
 ## Installation
 

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -38,7 +38,7 @@ function intersections(array1, array2) {
 
 const LightTable = Component.extend({
   layout,
-  classNameBindings: [':ember-light-table'],
+  classNameBindings: [':ember-light-table', 'occlusion'],
   attributeBindings: ['style'],
 
   media: service(),
@@ -160,6 +160,27 @@ const LightTable = Component.extend({
   breakpoints: null,
 
   /**
+   * Toggles occlusion rendering functionality. Currently experimental.
+   * If set to true, you must set {{#crossLink 't.body/estimatedRowHeight:property'}}{{/crossLink}} to
+   * something other than the default value.
+   *
+   * @property occlusion
+   * @type Boolean
+   * @default False
+   */
+  occlusion: false,
+
+  /**
+   * Estimated size of a row. Used in `vertical-collection` to determine roughly the number
+   * of rows exist out of the viewport.
+   *
+   * @property estimatedRowHeight
+   * @type Number
+   * @default false
+   */
+  estimatedRowHeight: 0,
+
+  /**
    * Table component shared options
    *
    * @property sharedOptions
@@ -170,7 +191,9 @@ const LightTable = Component.extend({
     return {
       height: this.get('height'),
       fixedHeader: false,
-      fixedFooter: false
+      fixedFooter: false,
+      occlusion: this.get('occlusion'),
+      estimatedRowHeight: this.get('estimatedRowHeight')
     };
   }).readOnly(),
 

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -446,9 +446,7 @@ export default Component.extend({
 
       if (canSelect) {
         if (e.shiftKey && multiSelect) {
-          rows
-          .slice(Math.min(currIndex, prevIndex), Math.max(currIndex, prevIndex) + 1)
-          .forEach((r) => r.set('selected', !isSelected));
+          rows.slice(Math.min(currIndex, prevIndex), Math.max(currIndex, prevIndex) + 1).forEach((r) => r.set('selected', !isSelected));
         } else if ((!multiSelectRequiresKeyboard || (e.ctrlKey || e.metaKey)) && multiSelect) {
           row.toggleProperty('selected');
         } else {

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -163,6 +163,8 @@ export default Component.extend({
    */
   overwrite: false,
 
+  occlusion: false,
+
   /**
    * If true, the body will prepend an invisible `<tr>` that scaffolds the
    * widths of the table cells.

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -318,6 +318,15 @@ export default Component.extend({
     this.setupScrollOffset();
   },
 
+  didInsertElement(){
+    this._super(...arguments);
+    const lightTableContainer = this.element.parentElement;
+    const totalHeight = lightTableContainer.getBoundingClientRect().height;
+    const headerElem = lightTableContainer.querySelector('.lt-head-wrap');
+    const headerHeight = headerElem.getBoundingClientRect().height;
+    this.set('height', totalHeight - headerHeight);
+  },
+
   destroy() {
     this._super(...arguments);
     run.cancel(this._checkTargetOffsetTimer);

--- a/addon/components/lt-body.js
+++ b/addon/components/lt-body.js
@@ -163,8 +163,6 @@ export default Component.extend({
    */
   overwrite: false,
 
-  occlusion: false,
-
   /**
    * If true, the body will prepend an invisible `<tr>` that scaffolds the
    * widths of the table cells.
@@ -318,19 +316,33 @@ export default Component.extend({
     this.setupScrollOffset();
   },
 
-  didInsertElement(){
+  didInsertElement() {
     this._super(...arguments);
-    const lightTableContainer = this.element.parentElement;
-    const totalHeight = lightTableContainer.getBoundingClientRect().height;
-    const headerElem = lightTableContainer.querySelector('.lt-head-wrap');
-    const headerHeight = headerElem.getBoundingClientRect().height;
-    this.set('height', totalHeight - headerHeight);
+    if (this.get('sharedOptions.occlusion')) {
+      this._setupScrollAreaDimensions();
+    }
   },
 
   destroy() {
     this._super(...arguments);
     run.cancel(this._checkTargetOffsetTimer);
     run.cancel(this._setTargetOffsetTimer);
+  },
+
+  /**
+   * Calculates the available height remaining in the body of the table by taking the table height defined
+   * on the light table component and subtracting the rendered height of the header.
+   * May need to extend this to include the footer.
+   *
+   * @method _setupScrollAreaDimensions
+   * @private
+   */
+  _setupScrollAreaDimensions() {
+    const lightTableContainer = this.element.parentElement;
+    const { height: totalHeight } = lightTableContainer.getBoundingClientRect();
+    const headerElem = lightTableContainer.querySelector('.lt-head-wrap');
+    const { height: headerHeight } = headerElem.getBoundingClientRect();
+    this.set('height', totalHeight - headerHeight);
   },
 
   _setupVirtualScrollbar() {
@@ -435,8 +447,8 @@ export default Component.extend({
       if (canSelect) {
         if (e.shiftKey && multiSelect) {
           rows
-            .slice(Math.min(currIndex, prevIndex), Math.max(currIndex, prevIndex) + 1)
-            .forEach((r) => r.set('selected', !isSelected));
+          .slice(Math.min(currIndex, prevIndex), Math.max(currIndex, prevIndex) + 1)
+          .forEach((r) => r.set('selected', !isSelected));
         } else if ((!multiSelectRequiresKeyboard || (e.ctrlKey || e.metaKey)) && multiSelect) {
           row.toggleProperty('selected');
         } else {

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -68,7 +68,7 @@
 }
 
 /* This is for when useVirtualScrollbar is disabled */
-.ember-light-table .lt-head-wrap {
+.ember-light-table.occlusion .lt-head-wrap {
   padding-right: 14px;
 }
 

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -72,6 +72,10 @@
   padding-right: 14px;
 }
 
+.ember-light-table.occlusion .lt-head-wrap table {
+  display: inline
+}
+
 .ember-light-table vertical-collection {
   display: table;
   table-layout: fixed;

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -72,6 +72,15 @@
   padding-right: 14px;
 }
 
+.ember-light-table vertical-collection {
+  display: table;
+  table-layout: fixed;
+}
+
+.ember-light-table vertical-collection occluded-content:first-of-type {
+  display: table-caption;
+}
+
 .ember-light-table .align-left {
   text-align: left;
 }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -63,6 +63,15 @@
           flex: 1 0 auto;
 }
 
+.ember-light-table .lt-scrollable.vertical-collection {
+  overflow-y: auto;
+}
+
+/* This is for when useVirtualScrollbar is disabled */
+.ember-light-table .lt-head-wrap {
+  padding-right: 14px;
+}
+
 .ember-light-table .align-left {
   text-align: left;
 }

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -1,20 +1,21 @@
 {{#with (hash
-    row=(or rowComponent (component 'lt-row'))
-    spanned-row=(or spannedRowComponent (component 'lt-spanned-row'))
-    infinity=(or infinityComponent (component 'lt-infinity'))
-  ) as |lt|
+          row=(or rowComponent (component 'lt-row'))
+          spanned-row=(or spannedRowComponent (component 'lt-spanned-row'))
+          infinity=(or infinityComponent (component 'lt-infinity'))
+        ) as |lt|
 }}
-  {{#lt-scrollable
-    tagName=''
-    virtualScrollbar=useVirtualScrollbar
-    autoHide=autoHideScrollbar
-    scrollTo=targetScrollOffset
-    onScrollY=(action 'onScroll')
-  }}
-    <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>
+  {{#unless occlusion}}
+    {{#lt-scrollable
+      tagName=''
+      virtualScrollbar=useVirtualScrollbar
+      autoHide=autoHideScrollbar
+      scrollTo=targetScrollOffset
+      onScrollY=(action 'onScroll')
+    }}
+      <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>
 
-    <table class={{tableClassNames}}>
-      <tbody class="lt-body">
+      <table class={{tableClassNames}}>
+        <tbody class="lt-body">
         {{#if enableScaffolding}}
           <tr class="lt-scaffolding-row">
             {{#each columns as |column|}}
@@ -28,36 +29,106 @@
         {{else}}
           {{#each rows as |row|}}
             {{lt.row row columns
-              data-row-id=row.rowId
-              table=table
-              tableActions=tableActions
-              extra=extra
-              enableScaffolding=enableScaffolding
-              canExpand=canExpand
-              canSelect=canSelect
-              click=(action 'onRowClick' row)
-              doubleClick=(action 'onRowDoubleClick' row)}}
+                     data-row-id=row.rowId
+                     table=table
+                     tableActions=tableActions
+                     extra=extra
+                     enableScaffolding=enableScaffolding
+                     canExpand=canExpand
+                     canSelect=canSelect
+                     click=(action 'onRowClick' row)
+                     doubleClick=(action 'onRowDoubleClick' row)}}
 
             {{yield (hash
-              expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
-              loader=(component lt.spanned-row visible=false)
-              no-data=(component lt.spanned-row visible=false)
-            ) rows}}
+                      expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
+                      loader=(component lt.spanned-row visible=false)
+                      no-data=(component lt.spanned-row visible=false)
+                    ) rows}}
           {{/each}}
 
           {{yield (hash
-            loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
-            no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
-            expanded-row=(component lt.spanned-row visible=false)
-          ) rows}}
+                    loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
+                    no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
+                    expanded-row=(component lt.spanned-row visible=false)
+                  ) rows}}
         {{/if}}
-      </tbody>
-    </table>
+        </tbody>
+      </table>
 
-    {{#if onScrolledToBottom}}
-      {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
-    {{/if}}
+      {{#if onScrolledToBottom}}
+        {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
+      {{/if}}
 
-    <div id={{concat tableId '_inline_foot'}} class="lt-inline lt-foot"></div>
-  {{/lt-scrollable}}
+      <div id={{concat tableId '_inline_foot'}} class="lt-inline lt-foot"></div>
+    {{/lt-scrollable}}
+  {{else}}
+    {{#lt-scrollable
+      tagName=''
+      virtualScrollbar=false
+      autoHide=autoHideScrollbar
+      scrollTo=targetScrollOffset
+      onScrollY=(action 'onScroll')
+    }}
+      <div class="lt-scrollable tse-scrollable vertical-collection">
+        <!-- TODO this is a temporary state to observe what would happen without light table
+            computed width from ember-scrollable is 662px; and we remove 14px for the scrollbar
+            648px
+        -->
+        <div class="" style="width: 648px; height: 574.297px;">
+          <div class="">
+            <div id="{{concat tableId '_inline_head'}}" class="lt-inline lt-head"></div>
+
+            <table class={{tableClassNames}}>
+              <tbody class="lt-body">
+              {{#if enableScaffolding}}
+                <tr class="lt-scaffolding-row">
+                  {{#each columns as |column|}}
+                    <td
+                      style={{html-safe (if column.width (concat 'width: ' column.width))}} class="lt-scaffolding"></td>
+                  {{/each}}
+                </tr>
+              {{/if}}
+
+              {{#if overwrite}}
+                {{yield columns rows}}
+              {{else}}
+                {{#each rows as |row|}}
+                  {{lt.row row columns
+                           data-row-id=row.rowId
+                           table=table
+                           tableActions=tableActions
+                           extra=extra
+                           enableScaffolding=enableScaffolding
+                           canExpand=canExpand
+                           canSelect=canSelect
+                           click=(action 'onRowClick' row)
+                           doubleClick=(action 'onRowDoubleClick' row)}}
+
+                  {{yield (hash
+                            expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
+                            loader=(component lt.spanned-row visible=false)
+                            no-data=(component lt.spanned-row visible=false)
+                          ) rows}}
+                {{/each}}
+
+                {{yield (hash
+                          loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
+                          no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
+                          expanded-row=(component lt.spanned-row visible=false)
+                        ) rows}}
+              {{/if}}
+              </tbody>
+            </table>
+
+            {{#if onScrolledToBottom}}
+              {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
+            {{/if}}
+
+            <div id="{{concat tableId '_inline_foot'}}" class="lt-inline lt-foot">
+            </div>
+          </div>
+        </div>
+      </div>
+    {{/lt-scrollable}}
+  {{/unless}}
 {{/with}}

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -4,7 +4,7 @@
           infinity=(or infinityComponent (component 'lt-infinity'))
         ) as |lt|
 }}
-  {{#unless occlusion}}
+  {{#unless sharedOptions.occlusion}}
     {{#lt-scrollable
       tagName=''
       virtualScrollbar=useVirtualScrollbar
@@ -62,67 +62,62 @@
       <div id={{concat tableId '_inline_foot'}} class="lt-inline lt-foot"></div>
     {{/lt-scrollable}}
   {{else}}
-    <div class="lt-scrollable tse-scrollable vertical-collection">
-      <div class="thing-that-scrolls" style="{{html-safe (concat 'height:' height 'px')}}">
-        <div class="">
-          <div id="{{concat tableId '_inline_head'}}" class="lt-inline lt-head"></div>
+    <div class="lt-scrollable tse-scrollable vertical-collection" style="{{html-safe (concat 'height:' height 'px')}}">
+      <div id="{{concat tableId '_inline_head'}}" class="lt-inline lt-head"></div>
 
-          <table class={{tableClassNames}}>
-            <tbody class="lt-body">
-            {{#if enableScaffolding}}
-              <tr class="lt-scaffolding-row">
-                {{#each columns as |column|}}
-                  <td
-                    style={{html-safe (if column.width (concat 'width: ' column.width))}} class="lt-scaffolding"></td>
-                {{/each}}
-              </tr>
-            {{/if}}
+      <table class={{tableClassNames}}>
+        <tbody class="lt-body">
+        {{#if enableScaffolding}}
+          <tr class="lt-scaffolding-row">
+            {{#each columns as |column|}}
+              <td
+                style={{html-safe (if column.width (concat 'width: ' column.width))}} class="lt-scaffolding"></td>
+            {{/each}}
+          </tr>
+        {{/if}}
 
-            {{#if overwrite}}
-              {{yield columns rows}}
-            {{else}}
-              {{#vertical-collection rows
-                                     estimateHeight=90
-                                     containerSelector='.lt-scrollable'
+        {{#if overwrite}}
+          {{yield columns rows}}
+        {{else}}
+          {{#vertical-collection
+              rows
+              estimateHeight=sharedOptions.estimatedRowHeight
+              containerSelector='.lt-scrollable'
+             as |row index|
+          }}
+            {{lt.row row columns
+                     data-row-id=row.rowId
+                     table=table
+                     tableActions=tableActions
+                     extra=extra
+                     enableScaffolding=enableScaffolding
+                     canExpand=canExpand
+                     canSelect=canSelect
+                     click=(action 'onRowClick' row)
+                     doubleClick=(action 'onRowDoubleClick' row)}}
 
-              as |row index|
-              }}
-                {{lt.row row columns
-                         data-row-id=row.rowId
-                         table=table
-                         tableActions=tableActions
-                         extra=extra
-                         enableScaffolding=enableScaffolding
-                         canExpand=canExpand
-                         canSelect=canSelect
-                         click=(action 'onRowClick' row)
-                         doubleClick=(action 'onRowDoubleClick' row)}}
+            {{yield (hash
+                      expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
+                      loader=(component lt.spanned-row visible=false)
+                      no-data=(component lt.spanned-row visible=false)
+                    ) rows}}
 
-                {{yield (hash
-                          expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
-                          loader=(component lt.spanned-row visible=false)
-                          no-data=(component lt.spanned-row visible=false)
-                        ) rows}}
+          {{/vertical-collection}}
+          {{yield (hash
+                    loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
+                    no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
+                    expanded-row=(component lt.spanned-row visible=false)
+                  ) rows}}
+        {{/if}}
+        </tbody>
+      </table>
 
-              {{/vertical-collection}}
-              {{yield (hash
-                        loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
-                        no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
-                        expanded-row=(component lt.spanned-row visible=false)
-                      ) rows}}
-            {{/if}}
-            </tbody>
-          </table>
+      {{!--#if onScrolledToBottom}} TODO figure out how to use the scrollbuffer property for infinite loading
+                                           lastReached=onScrolledToBottom
+        {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
+      {{/if --}}
 
-          {{!--#if onScrolledToBottom}}
-                                               lastReached=onScrolledToBottom
-            {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
-          {{/if --}}
-
-          <div id="{{concat tableId '_inline_foot'}}" class="lt-inline lt-foot">
-          </div>
-        </div>
-      </div>
+      <div id="{{concat tableId '_inline_foot'}}" class="lt-inline lt-foot"></div>
     </div>
   {{/unless}}
 {{/with}}

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -62,73 +62,67 @@
       <div id={{concat tableId '_inline_foot'}} class="lt-inline lt-foot"></div>
     {{/lt-scrollable}}
   {{else}}
-    {{#lt-scrollable
-      tagName=''
-      virtualScrollbar=false
-      autoHide=autoHideScrollbar
-      scrollTo=targetScrollOffset
-      onScrollY=(action 'onScroll')
-    }}
-      <div class="lt-scrollable tse-scrollable vertical-collection">
-        <!-- TODO this is a temporary state to observe what would happen without light table
-            computed width from ember-scrollable is 662px; and we remove 14px for the scrollbar
-            648px
-        -->
-        <div class="" style="width: 648px; height: 574.297px;">
-          <div class="">
-            <div id="{{concat tableId '_inline_head'}}" class="lt-inline lt-head"></div>
+    <div class="lt-scrollable tse-scrollable vertical-collection">
+      <div class="thing-that-scrolls" style="{{html-safe (concat 'height:' height 'px')}}">
+        <div class="">
+          <div id="{{concat tableId '_inline_head'}}" class="lt-inline lt-head"></div>
 
-            <table class={{tableClassNames}}>
-              <tbody class="lt-body">
-              {{#if enableScaffolding}}
-                <tr class="lt-scaffolding-row">
-                  {{#each columns as |column|}}
-                    <td
-                      style={{html-safe (if column.width (concat 'width: ' column.width))}} class="lt-scaffolding"></td>
-                  {{/each}}
-                </tr>
-              {{/if}}
-
-              {{#if overwrite}}
-                {{yield columns rows}}
-              {{else}}
-                {{#each rows as |row|}}
-                  {{lt.row row columns
-                           data-row-id=row.rowId
-                           table=table
-                           tableActions=tableActions
-                           extra=extra
-                           enableScaffolding=enableScaffolding
-                           canExpand=canExpand
-                           canSelect=canSelect
-                           click=(action 'onRowClick' row)
-                           doubleClick=(action 'onRowDoubleClick' row)}}
-
-                  {{yield (hash
-                            expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
-                            loader=(component lt.spanned-row visible=false)
-                            no-data=(component lt.spanned-row visible=false)
-                          ) rows}}
+          <table class={{tableClassNames}}>
+            <tbody class="lt-body">
+            {{#if enableScaffolding}}
+              <tr class="lt-scaffolding-row">
+                {{#each columns as |column|}}
+                  <td
+                    style={{html-safe (if column.width (concat 'width: ' column.width))}} class="lt-scaffolding"></td>
                 {{/each}}
-
-                {{yield (hash
-                          loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
-                          no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
-                          expanded-row=(component lt.spanned-row visible=false)
-                        ) rows}}
-              {{/if}}
-              </tbody>
-            </table>
-
-            {{#if onScrolledToBottom}}
-              {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
+              </tr>
             {{/if}}
 
-            <div id="{{concat tableId '_inline_foot'}}" class="lt-inline lt-foot">
-            </div>
+            {{#if overwrite}}
+              {{yield columns rows}}
+            {{else}}
+              {{#vertical-collection rows
+                                     estimateHeight=90
+                                     containerSelector='.lt-scrollable'
+
+              as |row index|
+              }}
+                {{lt.row row columns
+                         data-row-id=row.rowId
+                         table=table
+                         tableActions=tableActions
+                         extra=extra
+                         enableScaffolding=enableScaffolding
+                         canExpand=canExpand
+                         canSelect=canSelect
+                         click=(action 'onRowClick' row)
+                         doubleClick=(action 'onRowDoubleClick' row)}}
+
+                {{yield (hash
+                          expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
+                          loader=(component lt.spanned-row visible=false)
+                          no-data=(component lt.spanned-row visible=false)
+                        ) rows}}
+
+              {{/vertical-collection}}
+              {{yield (hash
+                        loader=(component lt.spanned-row classes='lt-is-loading' colspan=colspan)
+                        no-data=(component lt.spanned-row classes='lt-no-data' colspan=colspan)
+                        expanded-row=(component lt.spanned-row visible=false)
+                      ) rows}}
+            {{/if}}
+            </tbody>
+          </table>
+
+          {{!--#if onScrolledToBottom}}
+                                               lastReached=onScrolledToBottom
+            {{lt.infinity rows=rows onScrolledToBottom=onScrolledToBottom scrollBuffer=scrollBuffer}}
+          {{/if --}}
+
+          <div id="{{concat tableId '_inline_foot'}}" class="lt-inline lt-foot">
           </div>
         </div>
       </div>
-    {{/lt-scrollable}}
+    </div>
   {{/unless}}
 {{/with}}

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -81,6 +81,7 @@
         {{else}}
           {{#vertical-collection
               rows
+              tagName='vertical-collection'
               estimateHeight=sharedOptions.estimatedRowHeight
               containerSelector='.lt-scrollable'
              as |row index|

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "@html-next/vertical-collection": "^1.0.0-beta.9",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.2",
     "ember-cli-string-helpers": "^1.5.0",
@@ -34,7 +35,6 @@
     "ember-wormhole": "^0.5.1"
   },
   "devDependencies": {
-    "@html-next/vertical-collection": "^1.0.0-beta.8",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.13.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-wormhole": "^0.5.1"
   },
   "devDependencies": {
+    "@html-next/vertical-collection": "^1.0.0-beta.8",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.13.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-get-config": "^0.2.2",
     "ember-in-viewport": "2.1.1",
     "ember-scrollable": "^0.4.7",
-    "ember-truth-helpers": "1.3.0",
+    "ember-truth-helpers": "^2.0.0",
     "ember-wormhole": "^0.5.1"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "ember-font-awesome": "^3.0.5",
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-helpers": "^0.5.0",
-    "ember-one-way-controls": "2.0.0",
+    "ember-one-way-controls": "^2.0.0",
     "ember-owner-test-utils": "^0.1.2",
     "ember-resolver": "^4.0.0",
     "ember-responsive": "^2.0.4",

--- a/tests/dummy/app/components/cookbook/occluded-table.js
+++ b/tests/dummy/app/components/cookbook/occluded-table.js
@@ -4,6 +4,7 @@ import TableCommon from '../../mixins/table-common';
 import { computed } from '@ember/object';
 
 export default Component.extend(TableCommon, {
+  limit: 200,
   columns: computed(function() {
     return [{
       label: 'Avatar',
@@ -29,6 +30,12 @@ export default Component.extend(TableCommon, {
       label: 'Country',
       valuePath: 'country'
     }];
-  })
+  }),
+
+  init(){
+    this._super(...arguments);
+    this.set('page', 1);
+    this.get('fetchRecords').perform();
+  }
 });
 // END-SNIPPET

--- a/tests/dummy/app/components/cookbook/occluded-table.js
+++ b/tests/dummy/app/components/cookbook/occluded-table.js
@@ -1,0 +1,34 @@
+// BEGIN-SNIPPET occluded-table
+import Component from '@ember/component';
+import TableCommon from '../../mixins/table-common';
+import { computed } from '@ember/object';
+
+export default Component.extend(TableCommon, {
+  columns: computed(function() {
+    return [{
+      label: 'Avatar',
+      valuePath: 'avatar',
+      width: '60px',
+      sortable: false,
+      cellComponent: 'user-avatar'
+    }, {
+      label: 'First Name',
+      valuePath: 'firstName',
+      width: '150px'
+    }, {
+      label: 'Last Name',
+      valuePath: 'lastName',
+      width: '150px'
+    }, {
+      label: 'Address',
+      valuePath: 'address'
+    }, {
+      label: 'State',
+      valuePath: 'state'
+    }, {
+      label: 'Country',
+      valuePath: 'country'
+    }];
+  })
+});
+// END-SNIPPET

--- a/tests/dummy/app/components/cookbook/occluded-table.js
+++ b/tests/dummy/app/components/cookbook/occluded-table.js
@@ -4,7 +4,7 @@ import TableCommon from '../../mixins/table-common';
 import { computed } from '@ember/object';
 
 export default Component.extend(TableCommon, {
-  limit: 200,
+  limit: 100,
   columns: computed(function() {
     return [{
       label: 'Avatar',
@@ -22,13 +22,16 @@ export default Component.extend(TableCommon, {
       width: '150px'
     }, {
       label: 'Address',
-      valuePath: 'address'
+      valuePath: 'address',
+      width: '150px'
     }, {
       label: 'State',
-      valuePath: 'state'
+      valuePath: 'state',
+      width: '100px'
     }, {
       label: 'Country',
-      valuePath: 'country'
+      valuePath: 'country',
+      width: '100px'
     }];
   }),
 

--- a/tests/dummy/app/components/cookbook/occluded-table.js
+++ b/tests/dummy/app/components/cookbook/occluded-table.js
@@ -35,7 +35,7 @@ export default Component.extend(TableCommon, {
     }];
   }),
 
-  init(){
+  init() {
     this._super(...arguments);
     this.set('page', 1);
     this.get('fetchRecords').perform();

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,10 +24,11 @@ Router.map(function() {
 
   this.route('cookbook', function() {
     this.route('client-side');
-    this.route('pagination');
     this.route('custom-row');
-    this.route('table-actions');
     this.route('horizontal-scrolling');
+    this.route('occlusion-rendering');
+    this.route('pagination');
+    this.route('table-actions');
   });
 });
 

--- a/tests/dummy/app/routes/cookbook/occlusion-rendering.js
+++ b/tests/dummy/app/routes/cookbook/occlusion-rendering.js
@@ -1,0 +1,1 @@
+export { default } from '../table-route';

--- a/tests/dummy/app/styles/table.less
+++ b/tests/dummy/app/styles/table.less
@@ -136,3 +136,10 @@ tfoot {
     }
   }
 }
+
+
+.ember-light-table.occlusion {
+  .lt-row td {
+    vertical-align: middle;
+  }
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -65,11 +65,14 @@
             {{#link-to 'cookbook.horizontal-scrolling' tagName="li"}}
               {{link-to 'Horizontal Scrolling' 'cookbook.horizontal-scrolling'}}
             {{/link-to}}
-            {{#link-to 'cookbook.table-actions' tagName="li"}}
-              {{link-to 'Table Actions' 'cookbook.table-actions'}}
+            {{#link-to 'cookbook.occlusion-rendering' tagName="li"}}
+              {{link-to 'Occlusion Rendering' 'cookbook.occlusion-rendering'}}
             {{/link-to}}
             {{#link-to 'cookbook.pagination' tagName="li"}}
               {{link-to 'Pagination' 'cookbook.pagination'}}
+            {{/link-to}}
+            {{#link-to 'cookbook.table-actions' tagName="li"}}
+              {{link-to 'Table Actions' 'cookbook.table-actions'}}
             {{/link-to}}
           </ul>
         {{/link-to}}

--- a/tests/dummy/app/templates/components/cookbook/occluded-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/occluded-table.hbs
@@ -16,8 +16,9 @@
   }}
 
   {{#t.body
-    occluded=true
+    occlusion=true
     canSelect=false
+    onScrolledToBottom=(action 'onScrolledToBottom')
   as |body|
   }}
     {{#if isLoading}}

--- a/tests/dummy/app/templates/components/cookbook/occluded-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/occluded-table.hbs
@@ -1,5 +1,9 @@
 {{!-- BEGIN-SNIPPET occluded-table --}}
-{{#light-table table height='65vh' as |t|}}
+{{#light-table table
+               height='65vh'
+               occlusion=true
+               estimatedRowHeight=50
+  as |t|}}
 
 {{!--
   In order for `fa-sort-asc` and `fa-sort-desc` icons to work,
@@ -8,15 +12,10 @@
 --}}
 
   {{t.head
-    onColumnClick=(action 'onColumnClick')
-    iconSortable='fa fa-sort'
-    iconAscending='fa fa-sort-asc'
-    iconDescending='fa fa-sort-desc'
     fixed=true
   }}
 
   {{#t.body
-    occlusion=true
     canSelect=false
     onScrolledToBottom=(action 'onScrolledToBottom')
   as |body|

--- a/tests/dummy/app/templates/components/cookbook/occluded-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/occluded-table.hbs
@@ -1,0 +1,30 @@
+{{!-- BEGIN-SNIPPET occluded-table --}}
+{{#light-table table height='65vh' as |t|}}
+
+{{!--
+  In order for `fa-sort-asc` and `fa-sort-desc` icons to work,
+  you need to have ember-font-awesome installed or manually include
+  the font-awesome assets, e.g. via a CDN.
+--}}
+
+  {{t.head
+    onColumnClick=(action 'onColumnClick')
+    iconSortable='fa fa-sort'
+    iconAscending='fa fa-sort-asc'
+    iconDescending='fa fa-sort-desc'
+    fixed=true
+  }}
+
+  {{#t.body
+    occluded=true
+    canSelect=false
+  as |body|
+  }}
+    {{#if isLoading}}
+      {{#body.loader}}
+        {{table-loader}}
+      {{/body.loader}}
+    {{/if}}
+  {{/t.body}}
+{{/light-table}}
+{{!-- END-SNIPPET --}}

--- a/tests/dummy/app/templates/cookbook/occlusion-rendering.hbs
+++ b/tests/dummy/app/templates/cookbook/occlusion-rendering.hbs
@@ -1,0 +1,11 @@
+{{#code-panel
+  title="Occluded Table"
+  snippets=(array
+    "occluded-table.js"
+    "table-common.js"
+    "occluded-table.hbs"
+    "user-avatar.hbs"
+    "table-loader.hbs"
+  )}}
+  {{cookbook/occluded-table model=model}}
+{{/code-panel}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,19 @@
   dependencies:
     "@glimmer/util" "^0.22.3"
 
+"@html-next/vertical-collection@^1.0.0-beta.8":
+  version "1.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.8.tgz#297e25c07f84aab040e5f25a901318306c9269ab"
+  dependencies:
+    babel-plugin-transform-es2015-block-scoping "^6.24.1"
+    babel6-plugin-strip-class-callcheck "^6.0.0"
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-rollup "^1.2.0"
+    ember-cli-babel "^6.0.0-beta.10"
+    ember-cli-htmlbars "^1.1.1"
+    ember-compatibility-helpers "^0.1.0"
+
 Base64@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.2.1.tgz#ba3a4230708e186705065e66babdd4c35cf60028"
@@ -175,6 +188,12 @@ amd-name-resolver@0.0.5:
 amd-name-resolver@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz#d3e4ba2dfcaab1d820c1be9de947c67828cfe595"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
+amd-name-resolver@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz#814301adfe8a2f109f6e84d5e935196efb669615"
   dependencies:
     ensure-posix-path "^1.0.1"
 
@@ -456,6 +475,14 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-core@^5.0.0, babel-core@^5.8.38:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-5.8.38.tgz#1fcaee79d7e61b750b00b8e54f6dfc9d0af86558"
@@ -683,6 +710,12 @@ babel-plugin-ember-modules-api-polyfill@^1.4.1:
   dependencies:
     ember-rfc176-data "^0.2.0"
 
+babel-plugin-ember-modules-api-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz#baaf26dcebe2ed1de120021bc42be29f520497b3"
+  dependencies:
+    ember-rfc176-data "^0.2.7"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -782,6 +815,16 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-plugin-transform-es2015-classes@^6.23.0:
   version "6.24.1"
@@ -1022,6 +1065,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -1031,6 +1081,16 @@ babel-template@^6.24.1, babel-template@^6.25.0:
     babel-types "^6.25.0"
     babylon "^6.17.2"
     lodash "^4.2.0"
+
+babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
 
 babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
@@ -1046,6 +1106,20 @@ babel-traverse@^6.24.1, babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
 babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
@@ -1054,6 +1128,15 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
+
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
 
 babel6-plugin-strip-class-callcheck@^6.0.0:
   version "6.0.0"
@@ -1070,6 +1153,10 @@ babylon@^5.8.38:
 babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 backbone@^1.1.2:
   version "1.3.3"
@@ -2583,6 +2670,23 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
+ember-cli-babel@^6.0.0-beta.10:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
+
 ember-cli-babel@^6.6.0:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.7.1.tgz#98de75cb3eaf3198a80aac36ae82d8ea48c9d91f"
@@ -3008,6 +3112,14 @@ ember-code-snippet@^1.9.0:
     glob "^4.0.4"
     highlight.js "^9.5.0"
 
+ember-compatibility-helpers@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.0.tgz#52dbe15fd67cd357fdf3d2bdb1221467c87947c3"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.0.0"
+    semver "^5.4.1"
+
 ember-component-inbound-actions@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ember-component-inbound-actions/-/ember-component-inbound-actions-1.0.1.tgz#9b354803c2d729f2d072999cc89ded69762e1dad"
@@ -3229,7 +3341,7 @@ ember-responsive@^2.0.4:
     ember-cli-babel "^6.4.1"
     ember-getowner-polyfill "^1.1.1"
 
-ember-rfc176-data@^0.2.0:
+ember-rfc176-data@^0.2.0, ember-rfc176-data@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
 
@@ -4243,7 +4355,7 @@ globals@^6.4.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/globals/-/globals-6.4.1.tgz#8498032b3b6d1cc81eebc5f79690d8fe29fabf4f"
 
-globals@^9.0.0, globals@^9.17.0:
+globals@^9.0.0, globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -4876,6 +4988,10 @@ js-tokens@1.0.1:
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.6.1, js-yaml@^3.8.4:
   version "3.8.4"
@@ -6587,6 +6703,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -6939,6 +7059,10 @@ sane@^1.1.1, sane@^1.6.0:
 semver@^4.3.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 semver@~5.1.0:
   version "5.1.1"
@@ -7526,7 +7650,7 @@ to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
 
-to-fast-properties@^1.0.0, to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.0, to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,10 +711,10 @@ babel-plugin-ember-modules-api-polyfill@^1.4.1:
     ember-rfc176-data "^0.2.0"
 
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz#baaf26dcebe2ed1de120021bc42be29f520497b3"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
   dependencies:
-    ember-rfc176-data "^0.2.7"
+    ember-rfc176-data "^0.3.0"
 
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
@@ -2670,7 +2670,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^6.0.0-beta.10:
+ember-cli-babel@^6.0.0-beta.10, ember-cli-babel@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2792,7 +2792,7 @@ ember-cli-htmlbars-inline-precompile@^0.4.0:
     hash-for-dep "^1.0.2"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.10, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
+ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.3.tgz#06815262c1577736235bd42ce99db559ce5ebfd1"
   dependencies:
@@ -2801,6 +2801,15 @@ ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.10, ember-cli-htmlbars@^1.0.3
     hash-for-dep "^1.0.2"
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
+
+ember-cli-htmlbars@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
+  dependencies:
+    broccoli-persistent-filter "^1.0.3"
+    hash-for-dep "^1.0.2"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
 
 ember-cli-htmlbars@^2.0.2:
   version "2.0.2"
@@ -3113,8 +3122,8 @@ ember-code-snippet@^1.9.0:
     highlight.js "^9.5.0"
 
 ember-compatibility-helpers@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.0.tgz#52dbe15fd67cd357fdf3d2bdb1221467c87947c3"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.1.tgz#70a26c0d28715bbb23eb1be343d7203e492afa68"
   dependencies:
     babel-plugin-debug-macros "^0.1.11"
     ember-cli-version-checker "^2.0.0"
@@ -3300,15 +3309,15 @@ ember-native-dom-helpers@^0.5.0:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.1.0"
 
-ember-one-way-controls@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-one-way-controls/-/ember-one-way-controls-2.0.0.tgz#7a79f1a56094c44fe1012fd0f9b75bd92d136fe9"
+ember-one-way-controls@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-one-way-controls/-/ember-one-way-controls-2.0.1.tgz#45bd9367554f69e10fa37dfac8f1a6c72360a7f1"
   dependencies:
-    ember-cli-babel "^5.1.7"
-    ember-cli-htmlbars "^1.0.10"
+    ember-cli-babel "^6.0.0"
+    ember-cli-htmlbars "^2.0.1"
     ember-get-helper "~1.1.0"
     ember-invoke-action "1.4.0"
-    ember-runtime-enumerable-includes-polyfill "^1.0.1"
+    ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
 ember-owner-test-utils@^0.1.2:
   version "0.1.2"
@@ -3341,22 +3350,19 @@ ember-responsive@^2.0.4:
     ember-cli-babel "^6.4.1"
     ember-getowner-polyfill "^1.1.1"
 
-ember-rfc176-data@^0.2.0, ember-rfc176-data@^0.2.7:
+ember-rfc176-data@^0.2.0:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
+
+ember-rfc176-data@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.0.tgz#6aee728cb521c5f80710990965027b9c320f6f08"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
   dependencies:
     recast "^0.11.3"
-
-ember-runtime-enumerable-includes-polyfill@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-1.0.4.tgz#16a7612e347a2edf07da8b2f2f09dbfee70deba0"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-version-checker "^1.1.6"
 
 ember-runtime-enumerable-includes-polyfill@^2.0.0:
   version "2.0.0"
@@ -3405,11 +3411,11 @@ ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
-ember-truth-helpers@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
+ember-truth-helpers@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.0.0.tgz#f3e2eef667859197f1328bb4f83b0b35b661c1ac"
   dependencies:
-    ember-cli-babel "^5.1.6"
+    ember-cli-babel "^6.8.2"
 
 ember-try-config@^2.0.1:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,9 +86,9 @@
   dependencies:
     "@glimmer/util" "^0.22.3"
 
-"@html-next/vertical-collection@^1.0.0-beta.8":
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.8.tgz#297e25c07f84aab040e5f25a901318306c9269ab"
+"@html-next/vertical-collection@^1.0.0-beta.9":
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.9.tgz#a23fe4d82e4ef059e955abe276f57f27269b37a5"
   dependencies:
     babel-plugin-transform-es2015-block-scoping "^6.24.1"
     babel6-plugin-strip-class-callcheck "^6.0.0"
@@ -97,7 +97,8 @@
     broccoli-rollup "^1.2.0"
     ember-cli-babel "^6.0.0-beta.10"
     ember-cli-htmlbars "^1.1.1"
-    ember-compatibility-helpers "^0.1.0"
+    ember-compatibility-helpers "^0.1.2"
+    ember-raf-scheduler "0.1.0"
 
 Base64@~0.2.0:
   version "0.2.1"
@@ -2670,7 +2671,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^6.0.0-beta.10, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.10, ember-cli-babel@^6.3.0, ember-cli-babel@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2694,23 +2695,6 @@ ember-cli-babel@^6.6.0:
     amd-name-resolver "0.0.6"
     babel-plugin-debug-macros "^0.1.11"
     babel-plugin-ember-modules-api-polyfill "^1.4.1"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.16.0"
-    babel-preset-env "^1.5.1"
-    broccoli-babel-transpiler "^6.1.2"
-    broccoli-debug "^0.6.2"
-    broccoli-funnel "^1.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^2.0.0"
-
-ember-cli-babel@^6.8.2:
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
-  dependencies:
-    amd-name-resolver "0.0.7"
-    babel-plugin-debug-macros "^0.1.11"
-    babel-plugin-ember-modules-api-polyfill "^2.0.1"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
     babel-polyfill "^6.16.0"
     babel-preset-env "^1.5.1"
@@ -3138,9 +3122,9 @@ ember-code-snippet@^1.9.0:
     glob "^4.0.4"
     highlight.js "^9.5.0"
 
-ember-compatibility-helpers@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.1.tgz#70a26c0d28715bbb23eb1be343d7203e492afa68"
+ember-compatibility-helpers@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.2.tgz#8eb1769ad761db273fd40242b1170d9f3841d0f0"
   dependencies:
     babel-plugin-debug-macros "^0.1.11"
     ember-cli-version-checker "^2.0.0"
@@ -3347,6 +3331,12 @@ ember-qunit@^2.1.3:
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.1.4.tgz#5732794e668f753d8fe1a353692ffeda73742d29"
   dependencies:
     ember-test-helpers "^0.6.3"
+
+ember-raf-scheduler@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-raf-scheduler/-/ember-raf-scheduler-0.1.0.tgz#a22a02d238c374499231c03ab9c5b9887c72a853"
+  dependencies:
+    ember-cli-babel "^6.6.0"
 
 ember-resolver@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
**WHY**
https://github.com/offirgolan/ember-light-table/issues/12 https://github.com/offirgolan/ember-light-table/issues/435
Especially https://github.com/offirgolan/ember-light-table/issues/12#issuecomment-318963414

**WHAT**
This PR introduces experimental integration with https://github.com/html-next/vertical-collection, as it is nearing a `1.0` in terms of stability. By setting the `occlusion=true` flag and setting a value for `estimatedRowHeight`, we deactivate `ember-scrollable` and use `vertical-collection` instead.

There is a new section in the cookbook `cookbook/occlusion-rendering` where an example is live

Some compromises with respect to functionality are made with this initial release so that it can get into people's hands and begin testing and playing with it. These are listed below:

**CAVEATS (To be turned into issues)**
- [ ] Must define widths for all columns -- Fixing this involves handling resize events, and making sure column widths stay synchronized across header / body tables
- [ ] Infinite render needs some TLC -- Fixing this involves usage/understanding of `scrollBuffer` property in ELT & vertical collection
- [ ] Fixed footer + occlusion rendering -- likely need to account for footer width when determining the width of the body as we did for the header.
- [ ] Native scrollbars (and 14px padding) are added -- integrating virtual scrollbars into `vertical collection` or `vertical collection` into `ember scrollable`
- [ ] Tests?