### PR TITLE
Update ember-scrollable to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-composable-helpers": "^2.0.1",
     "ember-get-config": "^0.2.2",
     "ember-in-viewport": "2.1.1",
-    "ember-scrollable": "^0.4.7",
+    "ember-scrollable": "^0.4.10",
     "ember-truth-helpers": "^2.0.0",
     "ember-wormhole": "^0.5.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,6 +2705,24 @@ ember-cli-babel@^6.6.0:
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
+ember-cli-babel@^6.8.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz#81424acd1d97fb13658168121eeb2007d6edee84"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
+
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.0.4.tgz#f43f42f75b7509c212fb926cd9aea86ae19264c6"
@@ -3010,6 +3028,13 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli-yuidoc@0.8.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/ember-cli-yuidoc/-/ember-cli-yuidoc-0.8.8.tgz#3858baaf85388a976024f9de40f1075fea58f606"
@@ -3130,11 +3155,11 @@ ember-compatibility-helpers@^0.1.2:
     ember-cli-version-checker "^2.0.0"
     semver "^5.4.1"
 
-ember-component-inbound-actions@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-component-inbound-actions/-/ember-component-inbound-actions-1.0.1.tgz#9b354803c2d729f2d072999cc89ded69762e1dad"
+ember-component-inbound-actions@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-component-inbound-actions/-/ember-component-inbound-actions-1.2.1.tgz#0f57c7a0cd969d56fbb6affc430189aacfff0779"
   dependencies:
-    ember-cli-babel "^5.1.5"
+    ember-cli-babel "^5.1.7"
 
 ember-composable-helpers@^2.0.1:
   version "2.0.2"
@@ -3271,11 +3296,11 @@ ember-invoke-action@1.4.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-ember-lifeline@^1.0.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-1.2.1.tgz#5d85bf8ddf7a2fa8edc43fd27454e7209da7f586"
+ember-lifeline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-2.0.0.tgz#ab2dadd3eed585605d1c4137c64aacec4d241c8e"
   dependencies:
-    ember-cli-babel "^5.1.7"
+    ember-cli-babel "^6.8.2"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"
@@ -3378,15 +3403,15 @@ ember-runtime-enumerable-includes-polyfill@^2.0.0:
     ember-cli-babel "^6.0.0"
     ember-cli-version-checker "^1.1.6"
 
-ember-scrollable@^0.4.7:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/ember-scrollable/-/ember-scrollable-0.4.8.tgz#1333ffeefd94959b75acd8a789de7228445d91a9"
+ember-scrollable@^0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/ember-scrollable/-/ember-scrollable-0.4.10.tgz#9a93f10b3699c92e356051ffd59119f0e68ef9c8"
   dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-htmlbars "^1.0.3"
-    ember-component-inbound-actions "1.0.1"
+    ember-cli-babel "^6.8.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-component-inbound-actions "1.2.1"
     ember-element-resize-detector "0.1.5"
-    ember-lifeline "^1.0.4"
+    ember-lifeline "^2.0.0"
 
 ember-source@~2.13.0:
   version "2.13.3"


### PR DESCRIPTION
This version bump of ember-scrollable just contains dependency updates.