### PR TITLE
Remove observer on viewportEntered

### DIFF
--- a/addon/components/lt-infinity.js
+++ b/addon/components/lt-infinity.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import { observer } from '@ember/object';
 import { run } from '@ember/runloop';
 import layout from '../templates/components/lt-infinity';
 import InViewportMixin from 'ember-in-viewport';
@@ -40,19 +39,6 @@ export default Component.extend(InViewportMixin, {
 
   didExitViewport() {
     this._cancelTimers();
-  },
-
-  scheduleScrolledToBottom: observer('rows.[]', 'viewportEntered', function() {
-    if (this.get('viewportEntered')) {
-      /*
-       Continue scheduling onScrolledToBottom until no longer in viewport
-       */
-      this._scheduleScrolledToBottom();
-    }
-  }),
-
-  _scheduleScrolledToBottom() {
-    this._schedulerTimer = run.scheduleOnce('afterRender', this, this._debounceScrolledToBottom);
   },
 
   _debounceScrolledToBottom(delay = 100) {


### PR DESCRIPTION
Saw some code that seems to make duplicate requests when the viewport is entered.  I'm sure this code was around for a reason in the beginning, so feel free to close as I might be missing something :+1:! 


To further clarify, I believe this line of [code](https://github.com/DockYard/ember-in-viewport/blob/master/addon/mixins/in-viewport.js#L154) in ember-in-viewport will trigger the method defined in `lt-infinity` and `viewportEntered` is targeted towards performing ancillary actions and not necessarily fetching more data for example.