### PR TITLE
Guard against undefined sourceColumn

### DIFF
--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -41,7 +41,7 @@ export default Mixin.create({
     /*
      A column is a valid drop target only if its in the same group
      */
-    return column.get('droppable') && column.get('parent') === sourceColumn.get('parent');
+    return sourceColumn && column.get('droppable') && column.get('parent') === sourceColumn.get('parent');
   }).volatile().readOnly(),
 
   dragStart(e) {


### PR DESCRIPTION
When dragging a non-column component over a column the mixin `draggable-column.js` checks to see if it is a drop target. This is fine when you are dragging a column but when a dragging something like a row `isDropTarget` fails as `sourceColumn` is undefined `sourceColumn.get('parent')`

This fix checks to see if `sourceColumn` is defined before trying to access `sourceColumn.get('parent')`