### PR TITLE
Use isArray to check columns, rows type

### DIFF
--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -1,4 +1,4 @@
-import { A as emberArray } from '@ember/array';
+import { A as emberArray, isArray } from '@ember/array';
 import { assert } from '@ember/debug';
 import EmberObject, { computed, get } from '@ember/object';
 import Row from 'ember-light-table/classes/Row';
@@ -149,8 +149,8 @@ export default class Table extends EmberObject.extend({
   constructor(columns = [], rows = [], options = {}) {
     super();
 
-    assert('[ember-light-table] columns must be an array if defined', columns instanceof Array);
-    assert('[ember-light-table] rows must be an array if defined', rows instanceof Array);
+    assert('[ember-light-table] columns must be an array if defined', isArray(columns));
+    assert('[ember-light-table] rows must be an array if defined', isArray(rows));
 
     let _options = mergeOptionsWithGlobals(options);
     let _columns = emberArray(Table.createColumns(columns));

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -1,6 +1,8 @@
 import { A as emberArray } from '@ember/array';
 import { Table, Column, Row } from 'ember-light-table';
 import { module, test } from 'qunit';
+import DS from 'ember-data';
+import EmberObject from '@ember/object';
 
 module('Unit | Classes | Table', function() {
   test('create table - default options', function(assert) {
@@ -31,6 +33,28 @@ module('Unit | Classes | Table', function() {
     assert.throws(() => {
       new Table(null, [{}]);
     }, /\[ember-light-table] columns must be an array if defined/, 'columns is not an array');
+  });
+
+  test('create table - with RecordArray instance as rows', function(assert) {
+    assert.expect(3);
+
+    let models = ['Tom', 'Yehuda', 'Tomster'].map((name) => {
+      return EmberObject.create({ name });
+    });
+
+    let rows = DS.RecordArray.create({
+      content: emberArray(models),
+      objectAtContent(index) {
+        return this.get('content')[index];
+      }
+    });
+
+    let columns = [{ label: 'Name', valuePath: 'name' }];
+    let table = new Table(columns, rows);
+
+    assert.ok(table);
+    assert.equal(table.get('rows.length'), 3);
+    assert.equal(table.get('columns.length'), 1);
   });
 
   test('reopen table', function(assert) {


### PR DESCRIPTION
This fixes table construction for ember data types such as `DS.RecordArray` and `DS.AdapterPopulatedRecordArray`. Otherwise it does not work with ember data’s `store.findAll('user')` result since `instanceof` check returns false.