### PR TITLE
change the property type of column className and cellClassName to be String only

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -248,7 +248,7 @@ export default class Column extends EmberObject.extend({
    * Class names to be applied to header and footer cells of this column
    *
    * @property classNames
-   * @type {String | Array}
+   * @type {String}
    */
   classNames: null,
 
@@ -256,7 +256,7 @@ export default class Column extends EmberObject.extend({
    * Class names to be applied to all cells of this column
    *
    * @property cellClassNames
-   * @type {String | Array}
+   * @type {String}
    */
   cellClassNames: null,
 


### PR DESCRIPTION
This is regarding the below issue.  
https://github.com/offirgolan/ember-light-table/issues/416

That's my first PR in open source community :)