### PR TITLE
Improve cells performance

### DIFF
--- a/addon/components/cells/base.js
+++ b/addon/components/cells/base.js
@@ -33,7 +33,7 @@ const Cell = Component.extend({
     }
 
     // For performance reasons, it's more interesting to bypass cssStyleify
-    // which can leads to a lot of garbage collections
+    // since it leads to a lot of garbage collections
     // when displaying many cells
     return columnWidth ? `width: ${htmlSafe(columnWidth)};` : '';
   }),

--- a/addon/components/cells/base.js
+++ b/addon/components/cells/base.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from 'ember-light-table/templates/components/cells/base';
-import cssStyleify from 'ember-light-table/utils/css-styleify';
+import { htmlSafe } from '@ember/string';
 
 /**
  * @module Light Table
@@ -26,12 +26,16 @@ const Cell = Component.extend({
 
   style: computed('enableScaffolding', 'column.width', function() {
     let column = this.get('column');
+    let columnWidth = column.get('width');
 
     if (this.get('enableScaffolding') || !column) {
       return '';
     }
 
-    return cssStyleify(column.getProperties(['width']));
+    // For performance reasons, it's more interesting to bypass cssStyleify
+    // which can leads to a lot of garbage collections
+    // when displaying many cells
+    return columnWidth ? `width: ${htmlSafe(columnWidth)};` : '';
   }),
 
   align: computed('column.align', function() {


### PR DESCRIPTION
This is related to #12 .
The utils method `cssStyleify` is not scalable when displaying many cells.
Indeed, the method do the following on every cell
- Introspect each object to get the keys
- Instantiate a new array
- Iterate over the `hash` object
- Try to dasherize the key
- `HtmlSafe` the returned string

This leads to a lot of memory management operations (including garbage collection phases) for the JS VM and it's very slow.
We can get a significant performance gain by bypassing `cssSyleify` in this case.