### PR TITLE
FIX - Incomplete use of htmlSafe() on Cell.style

### DIFF
--- a/addon/components/cells/base.js
+++ b/addon/components/cells/base.js
@@ -35,7 +35,7 @@ const Cell = Component.extend({
     // For performance reasons, it's more interesting to bypass cssStyleify
     // since it leads to a lot of garbage collections
     // when displaying many cells
-    return columnWidth ? `width: ${htmlSafe(columnWidth)};` : '';
+    return columnWidth ? htmlSafe(`width: ${columnWidth};`) : null;
   }),
 
   align: computed('column.align', function() {


### PR DESCRIPTION
Seeing large numbers of these warnings: `Binding style attributes may introduce cross-site scripting vulnerabilities ...` on Ember 3.3.2.

The empty string being returned when there is no `columnWidth` needed to be wrapped in `htmlSafe()` or changed to `null`. Also I think the `htmlSafe()` call needs to wrap the entire `width: ...` style.