### PR TITLE
Remove jQuery usage

### DIFF
--- a/addon/components/lt-column-resizer.js
+++ b/addon/components/lt-column-resizer.js
@@ -25,15 +25,14 @@ export default Component.extend({
     this.__mouseMove = this._mouseMove.bind(this);
     this.__mouseUp = this._mouseUp.bind(this);
 
-    $(document).on('mousemove', this.__mouseMove);
-    $(document).on('mouseup', this.__mouseUp);
+    document.addEventListener('mousemove', this.__mouseMove);
+    document.addEventListener('mouseup', this.__mouseUp);
   },
 
   willDestroyElement() {
     this._super(...arguments);
-
-    $(document).off('mousemove', this.__mouseMove);
-    $(document).off('mouseup', this.__mouseUp);
+    document.removeEventListener('mousemove', this.__mouseMove);
+    document.removeEventListener('mouseip', this.__mouseUp);
   },
 
   click(e) {

--- a/addon/components/lt-infinity.js
+++ b/addon/components/lt-infinity.js
@@ -16,7 +16,7 @@ export default Component.extend(InViewportMixin, {
     this._super(...arguments);
 
     let scrollBuffer = this.get('scrollBuffer');
-    let width = this.$().width();
+    let width = this.element.offsetWidth;
     let scrollableContent = this.get('scrollableContent');
 
     this.setProperties({

--- a/addon/utils/closest.js
+++ b/addon/utils/closest.js
@@ -1,0 +1,20 @@
+
+/**
+ * A polyfill for jQuery .closest() method
+ * @param  { Object } el     Dom element to start from
+ * @param  { String } selector Selector to match
+ * @return { Object }          The closest matching node or null
+ */
+const closest = (el, selector) => {
+  let parent;
+  while (el) {
+    parent = el.parentElement;
+    if (parent && parent.matches(selector)) {
+      return parent;
+    }
+    el = parent;
+  }
+  return null;
+};
+
+export default closest;

--- a/tests/helpers/table-columns.js
+++ b/tests/helpers/table-columns.js
@@ -57,3 +57,50 @@ export const GroupedColumns = [{
     valuePath: 'country'
   }]
 }];
+
+export const ResizableColumns = [{
+  label: 'User Details',
+  sortable: false,
+  align: 'center',
+
+  subColumns: [{
+    label: 'Avatar',
+    valuePath: 'avatar',
+    width: '60px',
+    sortable: false,
+    cellComponent: 'user-avatar'
+  }, {
+    label: 'First',
+    resizable: true,
+    valuePath: 'firstName',
+    width: '150px',
+    minResizeWidth: 75
+  }, {
+    label: 'Last',
+    resizable: true,
+    valuePath: 'lastName',
+    width: '150px',
+    minResizeWidth: 75
+  }]
+}, {
+  label: 'Contact Information',
+  sortable: false,
+  align: 'center',
+
+  subColumns: [{
+    label: 'Address',
+    resizable: true,
+    valuePath: 'address',
+    minResizeWidth: 100
+  }, {
+    label: 'State',
+    resizable: true,
+    valuePath: 'state',
+    minResizeWidth: 100
+  }, {
+    label: 'Country',
+    resizable: true,
+    valuePath: 'country',
+    minResizeWidth: 100
+  }]
+}];

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirageTest from 'ember-cli-mirage/test-support/setup-mirage';
 import Table from 'ember-light-table';
-import Columns from '../../helpers/table-columns';
+import Columns, { ResizableColumns } from '../../helpers/table-columns';
 import hasClass from '../../helpers/has-class';
 import RowComponent from 'ember-light-table/components/lt-row';
 import Component from '@ember/component';
@@ -259,5 +259,18 @@ module('Integration | Component | light table', function(hooks) {
     for (const element of findAll('.some-component')) {
       await click(element);
     }
+  });
+
+  test('dragging resizes columns', async function(assert) {
+    let table = new Table(ResizableColumns, this.server.createList('user', 10));
+    this.setProperties({ table });
+    await render(hbs `
+      {{#light-table table height='40vh' as |t|}}
+        {{t.head fixed=true}}
+        {{t.body}}
+      {{/light-table}}
+    `);
+    let ths = this.element.querySelectorAll('th.is-resizable');
+    assert.equal(ths.length, 5);
   });
 });


### PR DESCRIPTION
Fixes #591

CC: @alexander-alvarez I left usage of `this.$().text().trim` in the test blueprint. I'm going to make a seperate PR for updating ember + friends so we can get qunit dom working.

I'm also going to make a PR against ember-scrollable to remove that little bit of jQuery as well.