### PR TITLE
Expose shouldRecycle property of vertical-collection

### DIFF
--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -181,6 +181,17 @@ const LightTable = Component.extend({
   estimatedRowHeight: 0,
 
   /**
+   * Whether `vertical-collection` should recycle table rows. This speeds up performance with occlusion
+   * rendering but may cause problems if any components expect to reset their state to the initial state
+   * with every rerender of the list.
+   *
+   * @property shouldRecycle
+   * @type Boolean
+   * @default true
+   */
+  shouldRecycle: true,
+
+  /**
    * Table component shared options
    *
    * @property sharedOptions
@@ -193,7 +204,8 @@ const LightTable = Component.extend({
       fixedHeader: false,
       fixedFooter: false,
       occlusion: this.get('occlusion'),
-      estimatedRowHeight: this.get('estimatedRowHeight')
+      estimatedRowHeight: this.get('estimatedRowHeight'),
+      shouldRecycle: this.get('shouldRecycle')
     };
   }).readOnly(),
 

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -78,6 +78,7 @@
               rows
               tagName='vertical-collection'
               estimateHeight=sharedOptions.estimatedRowHeight
+              shouldRecycle=sharedOptions.shouldRecycle
               bufferSize=scrollBufferRows
               containerSelector='.lt-scrollable'
               firstVisibleChanged=(action 'firstVisibleChanged')


### PR DESCRIPTION
The shouldRecycle property of `vertical-collection` needs to be set to false in our app in order for the occlusion rendering to work due to our use of components within the table rows. This PR exposes the shouldRecycle property to apps so that it can be set to false if required.

shouldRecycle is defined here: https://github.com/html-next/vertical-collection/blob/37a88794f5ecc2e31abe76577d2f32db47a05b51/addon/components/vertical-collection/component.js#L81