### PR TITLE
FIX - Make ember-responsive a dependency not just a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-composable-helpers": "^2.1.0",
     "ember-get-config": "^0.2.4",
     "ember-in-viewport": "~3.0.3",
+    "ember-responsive": "^2.0.5",
     "ember-scrollable": "^0.5.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-wormhole": "^0.5.4"
@@ -69,7 +70,6 @@
     "ember-native-dom-helpers": "^0.6.2",
     "ember-one-way-controls": "^3.0.1",
     "ember-resolver": "^4.5.0",
-    "ember-responsive": "^2.0.5",
     "ember-source": "~3.1.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",


### PR DESCRIPTION
The main table component injects the `media` service, so `ember-responsive` needs to be listed as a dependency, not just a dev dependency.