### PR TITLE
Fixing issue with multiple tables and onScrolledToBottom.

### DIFF
--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -60,7 +60,7 @@
           rows=rows
           inViewport=(action "inViewport")
           exitViewport=(action "exitViewport")
-          scrollableContent=".lt-scrollable"}}
+          scrollableContent=(concat "#" tableId " .lt-scrollable")}}
       {{/if}}
 
       <div id={{concat tableId '_inline_foot'}} class="lt-inline lt-foot"></div>

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -54,6 +54,42 @@ module('Integration | Component | light table', function(hooks) {
     await scrollTo(scrollContainer, 0, scrollHeight);
   });
 
+  test('scrolled to bottom (multiple tables)', async function(assert) {
+    assert.expect(4);
+
+    this.set('table', new Table(Columns, this.server.createList('user', 50)));
+
+    this.set('onScrolledToBottomTable1', () => {
+      assert.ok(false);
+    });
+
+    this.set('onScrolledToBottomTable2', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs `
+      {{#light-table table height='40vh' id='table-1' as |t|}}
+        {{t.head fixed=true}}
+        {{t.body onScrolledToBottom=(action onScrolledToBottomTable1)}}
+      {{/light-table}}
+
+      {{#light-table table height='40vh' id='table-2' as |t|}}
+        {{t.head fixed=true}}
+        {{t.body onScrolledToBottom=(action onScrolledToBottomTable2)}}
+      {{/light-table}}
+    `);
+
+    assert.equal(findAll('#table-2 tbody > tr').length, 50, '50 rows are rendered');
+
+    let scrollContainer = '#table-2 .tse-scroll-content';
+    let { scrollHeight } = find(scrollContainer);
+
+    assert.ok(findAll(scrollContainer).length > 0, 'scroll container was rendered');
+    assert.equal(scrollHeight, 2501, 'scroll height is 2500 + 1px for height of lt-infinity');
+
+    await scrollTo(scrollContainer, 0, scrollHeight);
+  });
+
   test('fixed header', async function(assert) {
     assert.expect(2);
     this.set('table', new Table(Columns, this.server.createList('user', 5)));


### PR DESCRIPTION
When multiple tables were rendered to the document, only the first table would scroll correctly. This was due to the  selector referencing a class name and ember-in-viewport only selecting the first instance of that class. This commit prepends a table ID to that selector so that multiple tables with scrolling is supported.