### PR TITLE
Replace merge with assign

### DIFF
--- a/addon/-private/global-options.js
+++ b/addon/-private/global-options.js
@@ -1,4 +1,4 @@
-import { merge } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import config from 'ember-get-config';
 
 // eslint-disable-next-line ember-suave/no-direct-property-access
@@ -7,5 +7,5 @@ const globalOptions = config['ember-light-table'] || {};
 export default globalOptions;
 
 export function mergeOptionsWithGlobals(options) {
-  return merge(merge({}, globalOptions), options);
+  return assign(assign({}, globalOptions), options);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "@html-next/vertical-collection": "^1.0.0-beta.12",
+    "@html-next/vertical-collection": "^1.0.0-beta.13",
     "ember-cli-babel": "^6.11.0",
     "ember-cli-htmlbars": "^2.0.3",
     "ember-cli-string-helpers": "^1.8.1",


### PR DESCRIPTION
Fixes #667

Based on guide here https://deprecations.emberjs.com/v3.x/#toc_ember-polyfills-deprecate-merge

Given that this addon doesn't support <2.12 I've not bothered to include the assign polyfill, but let me know if you think we need to to anything further.