### PR TITLE
Fix deprecation: object.new-constructor #662

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -318,7 +318,7 @@ export default class Column extends EmberObject.extend({
   init(...args) {
     this._super(...args);
 
-    const subColumns = emberArray(makeArray(this.get('subColumns')).map((sc) => new Column(sc)));
+    const subColumns = emberArray(makeArray(this.get('subColumns')).map((sc) => Column.create(sc)));
     subColumns.setEach('parent', this);
 
     this.set('subColumns', subColumns);

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -147,6 +147,14 @@ export default class Table extends EmberObject.extend({
    *           `createRow(content, options)`.
    */
   constructor(columns = [], rows = [], options = {}) {
+    // this enables Table.create({}) api which fixes deprectation introduced in ember 3.6
+    if (!isArray(columns) && typeof columns === 'object' && columns !== null) {
+      options = columns;
+      rows = columns.rows || [];
+      columns = columns.columns || [];
+      delete options.rows;
+      delete options.columns;
+    }
     super();
 
     assert('[ember-light-table] columns must be an array if defined', isArray(columns));
@@ -433,7 +441,7 @@ export default class Table extends EmberObject.extend({
    * @return {Column}
    */
   static createColumn(column) {
-    return new Column(column);
+    return Column.create(column);
   }
 
   /**


### PR DESCRIPTION
Fixes #662

Now let me start by saying, I'm not sure this is the best solution BUT it does fix the deprecation errors while still supporting the existing API. 

Let me know what you think, any alternative solution is likely to require a discussion on where to take the API.