### PR TITLE
ensure ember-scrollable updates when rows are updated

### DIFF
--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -11,6 +11,7 @@
       autoHide=autoHideScrollbar
       scrollTo=targetScrollOffset
       onScrollY=(action 'onScroll')
+      as |scrollbar|
     }}
       <div id={{concat tableId '_inline_head'}} class="lt-inline lt-head"></div>
 
@@ -27,7 +28,7 @@
         {{#if overwrite}}
           {{yield columns rows}}
         {{else}}
-          {{#each rows as |row|}}
+          {{#each (if scrollbar (compute scrollbar.update rows) rows) as |row|}}
             {{lt.row row columns
                      data-row-id=row.rowId
                      table=table

--- a/addon/templates/components/lt-scrollable.hbs
+++ b/addon/templates/components/lt-scrollable.hbs
@@ -8,7 +8,7 @@
     onScrollY=onScrollY
     as |scrollbar|
   }}
-    {{yield}}
+    {{yield scrollbar}}
   {{/ember-scrollable}}
 {{else}}
   {{yield}}


### PR DESCRIPTION
Fixes #676 

Essentially this ensures that ember-scrollable is 'resized' when rows are updated - based on the ember-scrollable guidance [here](https://github.com/alphasights/ember-scrollable/blob/master/addon/components/ember-scrollable.js#L448...L470 ) 

Which comes from [this](https://github.com/alphasights/ember-scrollable/issues/85) ember-scrollable issue.

I'm not entirely sure the best way to test this - any ideas @alexander-alvarez ?