### PR TITLE
Set minimum supported ember version at 2.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
     - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-lts-3.4
     - EMBER_TRY_SCENARIO=ember-lts-3.8

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
 </div>
 
-[![Ember Versions](https://img.shields.io/badge/Ember.js%20Versions-%5E2.12%20and%20%5E3.0-brightgreen.svg)](https://travis-ci.org/offirgolan/ember-light-table)
+[![Ember Versions](https://img.shields.io/badge/Ember.js%20Versions-%5E2.18%20and%20%5E3.0-brightgreen.svg)](https://travis-ci.org/offirgolan/ember-light-table)
 [![Build Status](https://travis-ci.org/offirgolan/ember-light-table.svg)](https://travis-ci.org/offirgolan/ember-light-table)
 [![npm version](https://badge.fury.io/js/ember-light-table.svg)](http://badge.fury.io/js/ember-light-table)
 [![Download Total](https://img.shields.io/npm/dt/ember-light-table.svg)](http://badge.fury.io/js/ember-light-table)
@@ -37,7 +37,7 @@ Compatibility
 ------------------------------------------------------------------------------
 
 * Ember.js v2.18 or above
-* Ember CLI v2.13 or above
+* Ember CLI v2.18 or above
 
 
 Installation

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,22 +12,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
-          name: 'ember-lts-2.16',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.16.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.18',
           npm: {
             devDependencies: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-light-table",
   "version": "2.0.0-beta.3",
-  "description": "Lightweight, component based table for Ember 2.x",
+  "description": "Lightweight, component based table for Ember 2.18+",
   "keywords": [
     "ember-addon",
     "table"
@@ -93,7 +93,7 @@
     "configPath": "tests/dummy/config",
     "demoURL": "http://offirgolan.github.io/ember-light-table",
     "versionCompatibility": {
-      "ember": ">=2.3.0 <4.0.0"
+      "ember": ">=2.18.0 <4.0.0"
     }
   }
 }


### PR DESCRIPTION
Based on the community [survey results](https://emberjs.com/ember-community-survey-2019/) there is still enough of a user base for 2.18 that we'll need to maintain support for a little longer while people continue to upgrade to ember 3.x. 

2.18 is a sensible place to stop as a number of polyfills for new behaviour only go back to 2.18 and continuing to support older versions will make it harder to keep up with the pace of ember development.

Don't merge until #696 (sorry I stupidly chained these branches together locally).