### PR TITLE
WIP [BREAKING] fixes #444 #662 converts ES6 native classes to ember objects

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -315,33 +315,15 @@ export default class Column extends EmberObject.extend({
     return emberArray(isHidden ? [] : subColumns.filterBy('isHidden', false));
   }).readOnly(),
 
-  init(...args) {
-    this._super(...args);
+  init(options = {}) {
+    this.setProperties(options);
 
-    const subColumns = emberArray(makeArray(this.get('subColumns')).map((sc) => new Column(sc)));
+    const subColumns = emberArray(makeArray(this.get('subColumns')).map((sc) => Column.create(sc)));
     subColumns.setEach('parent', this);
 
     this.set('subColumns', subColumns);
   }
-}) {
-  /**
-   * @class Column
-   * @constructor
-   * @param {Object} options
-   */
-  constructor(options = {}) {
-    // TODO: Revert this, when babel#5862 is resolved.
-    //       https://github.com/babel/babel/issues/5862
-    // HACK: Passing properties to super instead of manually setting them fixes the
-    //       implicit run loop creation for Ember 2.12.
-    //       https://travis-ci.org/offirgolan/ember-light-table/jobs/344818839#L790
-    super(options);
-
-    if (options instanceof Column) {
-      return options;
-    }
-  }
-}
+}) {}
 
 // https://github.com/offirgolan/ember-light-table/issues/436#issuecomment-310138868
 fixProto(Column);

--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -77,26 +77,7 @@ export default class Row extends ObjectProxy.extend({
   rowId: computed(function() {
     return guidFor(this);
   }).readOnly()
-}) {
-  /**
-   * @class Row
-   * @constructor
-   * @param {Object} content
-   * @param {Object} options
-   */
-  constructor(content, options = {}) {
-    // TODO: Revert this, when babel#5862 is resolved.
-    //       https://github.com/babel/babel/issues/5862
-    // HACK: Passing properties to super instead of manually setting them fixes the
-    //       implicit run loop creation for Ember 2.12.
-    //       https://travis-ci.org/offirgolan/ember-light-table/jobs/344818839#L790
-    super(Object.assign({}, options, { content }));
-
-    if (content instanceof Row) {
-      return content;
-    }
-  }
-}
+}) {}
 
 // https://github.com/offirgolan/ember-light-table/issues/436#issuecomment-310138868
 fixProto(Row);

--- a/addon/index.js
+++ b/addon/index.js
@@ -27,7 +27,7 @@ import Row from './classes/Row';
  * ```javascript
  * import Table from 'ember-light-table';
  *
- * const table = new Table(columns, rows, options);
+ * const table = Table.create({ columns: columns, rows: rows });
  * ```
  *
  * Here is a more real-word example
@@ -59,7 +59,7 @@ import Row from './classes/Row';
  *   }),
  *
  *   table: computed('model', function() {
- *    return new Table(this.get('columns'), this.get('model'));
+ *    return Table.create({ columns: this.get('columns'), rows: this.get('model') });
  *   })
  * });
  * ```
@@ -72,7 +72,7 @@ import Row from './classes/Row';
  * ```javascript
  * import Table from 'ember-light-table';
  *
- * const table = new Table(columns, model, { enableSync: true });
+ * const table = Table.create({ columns: columns, rows: model, enableSync: true });
  * ```
  *
  * The `enableSync` options creates a __two way__ sync. This means that any manipulation

--- a/blueprints/cell-type-test/files/tests/integration/components/light-table/cells/__name__-test.js
+++ b/blueprints/cell-type-test/files/tests/integration/components/light-table/cells/__name__-test.js
@@ -12,8 +12,8 @@ test('it renders', function(assert) {
 });
 
 test('it renders value', function(assert) {
-  this.set('column', new Column({ valuePath: 'foo' }));
-  this.set('row', new Row({ foo: 'bar' }));
+  this.set('column', Column.create({ valuePath: 'foo' }));
+  this.set('row', Row.create({ content: { foo: 'bar' } }));
 
   this.render(hbs`{{light-table/cells/<%= dasherizedModuleName %> column row rawValue=(get row column.valuePath)}}`);
 

--- a/blueprints/column-type-test/files/tests/integration/components/light-table/columns/__name__-test.js
+++ b/blueprints/column-type-test/files/tests/integration/components/light-table/columns/__name__-test.js
@@ -12,7 +12,7 @@ test('it renders', function(assert) {
 });
 
 test('it renders label', function(assert) {
-  this.set('column', new Column({ label: '<%= dasherizedModuleName %>' }));
+  this.set('column', Column.create({ label: '<%= dasherizedModuleName %>' }));
 
   this.render(hbs`{{light-table/columns/<%= dasherizedModuleName %> column}}`);
 

--- a/tests/dummy/app/mixins/table-common.js
+++ b/tests/dummy/app/mixins/table-common.js
@@ -26,7 +26,7 @@ export default Mixin.create({
   init() {
     this._super(...arguments);
 
-    let table = new Table(this.get('columns'), this.get('model'), { enableSync: this.get('enableSync') });
+    let table = Table.create({ columns: this.get('columns'), rows: this.get('model'), enableSync: this.get('enableSync') });
     let sortColumn = table.get('allColumns').findBy('valuePath', this.get('sort'));
 
     // Setup initial sort column

--- a/tests/integration/components/light-table-occlusion-test.js
+++ b/tests/integration/components/light-table-occlusion-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
   });
 
   test('it renders', async function(assert) {
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs `{{light-table table height="40vh" occlusion=true estimatedRowHeight=30}}`);
 
     assert.equal(find('*').textContent.trim(), '');
@@ -32,7 +32,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
   test('scrolled to bottom', async function(assert) {
     assert.expect(4);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 50)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 50) }));
 
     this.set('onScrolledToBottom', () => {
       assert.ok(true);
@@ -58,7 +58,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
 
   test('fixed header', async function(assert) {
     assert.expect(2);
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `
       {{#light-table table height='500px' id='lightTable' occlusion=true estimatedRowHeight=30 as |t|}}
@@ -81,7 +81,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
 
   test('fixed footer', async function(assert) {
     assert.expect(2);
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `
       {{#light-table table height='500px' id='lightTable' occlusion=true estimatedRowHeight=30 as |t|}}
@@ -104,7 +104,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
 
   test('table assumes height of container', async function(assert) {
 
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
     this.set('fixed', true);
 
     await render(hbs `
@@ -121,7 +121,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
   });
 
   test('table body should consume all available space when not enough content to fill it', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
     this.set('fixed', true);
 
     await render(hbs `
@@ -148,7 +148,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
 
     this.owner.register('component:custom-row', RowComponent);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
 
     await render(hbs `
       {{#light-table table occlusion=true estimatedRowHeight=30 as |t|}}
@@ -170,7 +170,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
     }));
 
     let users = this.server.createList('user', 3);
-    this.set('table', new Table(Columns, users));
+    this.set('table', Table.create({ columns: Columns, rows: users }));
 
     await render(hbs `
       {{#light-table table height='500px' occlusion=true estimatedRowHeight=30 as |t|}}
@@ -222,7 +222,7 @@ module('Integration | Component | light table | occlusion', function(hooks) {
       cellComponent: 'some-component'
     }];
 
-    this.set('table', new Table(columns, [{}]));
+    this.set('table', Table.create({ columns, rows: [{}] }));
 
     this.actions.someAction = () => {
       assert.ok(true, 'table action is passed');

--- a/tests/integration/components/light-table-test.js
+++ b/tests/integration/components/light-table-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | light table', function(hooks) {
   });
 
   test('it renders', async function(assert) {
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs `{{light-table table}}`);
 
     assert.equal(find('*').textContent.trim(), '');
@@ -29,7 +29,7 @@ module('Integration | Component | light table', function(hooks) {
   test('scrolled to bottom', async function(assert) {
     assert.expect(4);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 50)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 50) }));
 
     this.set('onScrolledToBottom', () => {
       assert.ok(true);
@@ -56,7 +56,7 @@ module('Integration | Component | light table', function(hooks) {
   test('scrolled to bottom (multiple tables)', async function(assert) {
     assert.expect(4);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 50)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 50) }));
 
     this.set('onScrolledToBottomTable1', () => {
       assert.ok(false);
@@ -91,7 +91,7 @@ module('Integration | Component | light table', function(hooks) {
 
   test('lt-body inViewport event deprecated', async function(assert) {
     assert.expect(2);
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
     this.set('isInViewport', false);
     this.set('inViewport', () => {
       assert.ok(true);
@@ -114,7 +114,7 @@ module('Integration | Component | light table', function(hooks) {
 
   test('fixed header', async function(assert) {
     assert.expect(2);
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `
       {{#light-table table height='500px' id='lightTable' as |t|}}
@@ -137,7 +137,7 @@ module('Integration | Component | light table', function(hooks) {
 
   test('fixed footer', async function(assert) {
     assert.expect(2);
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `
       {{#light-table table height='500px' id='lightTable' as |t|}}
@@ -160,7 +160,7 @@ module('Integration | Component | light table', function(hooks) {
 
   test('table assumes height of container', async function(assert) {
 
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
     this.set('fixed', true);
 
     await render(hbs `
@@ -177,7 +177,7 @@ module('Integration | Component | light table', function(hooks) {
   });
 
   test('table body should consume all available space when not enough content to fill it', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
     this.set('fixed', true);
 
     await render(hbs `
@@ -204,7 +204,7 @@ module('Integration | Component | light table', function(hooks) {
 
     this.owner.register('component:custom-row', RowComponent);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
 
     await render(hbs `
       {{#light-table table as |t|}}
@@ -226,7 +226,7 @@ module('Integration | Component | light table', function(hooks) {
     }));
 
     let users = this.server.createList('user', 3);
-    this.set('table', new Table(Columns, users));
+    this.set('table', Table.create({ columns: Columns, rows: users }));
 
     await render(hbs `
       {{#light-table table as |t|}}
@@ -253,7 +253,7 @@ module('Integration | Component | light table', function(hooks) {
   });
 
   test('onScroll', async function(assert) {
-    let table = new Table(Columns, this.server.createList('user', 10));
+    let table = Table.create({ columns: Columns, rows: this.server.createList('user', 10) });
     let expectedScroll = 50;
 
     this.setProperties({
@@ -299,7 +299,7 @@ module('Integration | Component | light table', function(hooks) {
       cellComponent: 'some-component'
     }];
 
-    this.set('table', new Table(columns, [{}]));
+    this.set('table', Table.create({ columns, rows: [{}] }));
 
     this.actions.someAction = () => {
       assert.ok(true, 'table action is passed');
@@ -324,7 +324,7 @@ module('Integration | Component | light table', function(hooks) {
   });
 
   test('dragging resizes columns', async function(assert) {
-    let table = new Table(ResizableColumns, this.server.createList('user', 10));
+    let table = Table.create({ columns: ResizableColumns, rows: this.server.createList('user', 10) });
     this.setProperties({ table });
     await render(hbs `
       {{#light-table table height='40vh' as |t|}}

--- a/tests/integration/components/light-table/cells/base-test.js
+++ b/tests/integration/components/light-table/cells/base-test.js
@@ -9,21 +9,21 @@ module('Integration | Component | Cells | base', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    this.set('column', new Column());
+    this.set('column', Column.create());
     await render(hbs`{{light-table/cells/base column=column}}`);
 
     assert.equal(find('*').textContent.trim(), '');
   });
 
   test('cell with column format', async function(assert) {
-    this.set('column', new Column({
+    this.set('column', Column.create({
       valuePath: 'num',
       format(value) {
         return value * 2;
       }
     }));
 
-    this.set('row', new Row());
+    this.set('row', Row.create());
 
     await render(hbs`{{light-table/cells/base column row rawValue=2}}`);
 
@@ -31,15 +31,13 @@ module('Integration | Component | Cells | base', function(hooks) {
   });
 
   test('cell format with no valuePath', async function(assert) {
-    this.set('column', new Column({
+    this.set('column', Column.create({
       format() {
         return this.get('row.num') * 2;
       }
     }));
 
-    this.set('row', new Row({
-      num: 2
-    }));
+    this.set('row', Row.create({ content: { num: 2 } }));
 
     await render(hbs`{{light-table/cells/base column row}}`);
 
@@ -47,19 +45,19 @@ module('Integration | Component | Cells | base', function(hooks) {
   });
 
   test('cell with nested valuePath', async function(assert) {
-    this.set('column', new Column({
+    this.set('column', Column.create({
       valuePath: 'foo.bar.baz',
       format(value) {
         return value * 2;
       }
     }));
 
-    this.set('row', new Row({
+    this.set('row', Row.create({ content: {
       foo: {
         bar: {
           baz: 2
         }
-      }
+      } }
     }));
 
     await render(hbs`{{light-table/cells/base column row rawValue=(get row column.valuePath)}}`);

--- a/tests/integration/components/light-table/columns/base-test.js
+++ b/tests/integration/components/light-table/columns/base-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | Columns | base', function(hooks) {
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });"
-    this.set('column', new Column());
+    this.set('column', Column.create());
     await render(hbs`{{light-table/columns/base column=column}}`);
     assert.equal(find('*').textContent.trim(), '');
   });

--- a/tests/integration/components/lt-body-occlusion-test.js
+++ b/tests/integration/components/lt-body-occlusion-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | lt body | occlusion', function(hooks) {
   });
 
   test('row selection - enable or disable', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
     this.set('canSelect', false);
 
     await render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect}}`);
@@ -56,7 +56,7 @@ module('Integration | Component | lt body | occlusion', function(hooks) {
   });
 
   test('row selection - ctrl-click to modify selection', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `{{lt-body table=table scrollBuffer=200 sharedOptions=sharedOptions canSelect=true multiSelect=true}}`);
     let firstRow = find('tr:nth-child(2)');
@@ -79,7 +79,7 @@ module('Integration | Component | lt body | occlusion', function(hooks) {
   });
 
   test('row selection - click to modify selection', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(
       hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true multiSelectRequiresKeyboard=false}}`
@@ -107,7 +107,7 @@ module('Integration | Component | lt body | occlusion', function(hooks) {
   test('row actions', async function(assert) {
     assert.expect(2);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
     this.actions.onRowClick = (row) => assert.ok(row);
     this.actions.onRowDoubleClick = (row) => assert.ok(row);
     await render(
@@ -120,7 +120,7 @@ module('Integration | Component | lt body | occlusion', function(hooks) {
   });
 
   test('hidden rows', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `{{lt-body table=table sharedOptions=sharedOptions}}`);
 
@@ -143,7 +143,7 @@ module('Integration | Component | lt body | occlusion', function(hooks) {
   });
 
   test('overwrite', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `
       {{#lt-body table=table sharedOptions=sharedOptions overwrite=true as |columns rows|}}

--- a/tests/integration/components/lt-body-test.js
+++ b/tests/integration/components/lt-body-test.js
@@ -31,7 +31,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('row selection - enable or disable', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
     this.set('canSelect', false);
 
     await render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=canSelect tableId="light-table"}}`);
@@ -52,7 +52,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('row selection - ctrl-click to modify selection', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true tableId="light-table"}}`);
     let firstRow = find('tr:first-child');
@@ -75,7 +75,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('row selection - click to modify selection', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(
       hbs `{{lt-body table=table sharedOptions=sharedOptions canSelect=true multiSelect=true multiSelectRequiresKeyboard=false tableId="light-table"}}`
@@ -101,7 +101,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('row expansion', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 2)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 2) }));
     this.set('canExpand', false);
 
     await render(hbs `
@@ -136,7 +136,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('row expansion - multiple', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 2)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 2) }));
     await render(hbs `
       {{#lt-body table=table sharedOptions=sharedOptions canExpand=true tableId="light-table" as |b|}}
         {{#b.expanded-row}} Hello {{/b.expanded-row}}
@@ -160,7 +160,7 @@ module('Integration | Component | lt body', function(hooks) {
   test('row actions', async function(assert) {
     assert.expect(2);
 
-    this.set('table', new Table(Columns, this.server.createList('user', 1)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 1) }));
     this.actions.onRowClick = (row) => assert.ok(row);
     this.actions.onRowDoubleClick = (row) => assert.ok(row);
     await render(
@@ -173,7 +173,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('hidden rows', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `{{lt-body table=table sharedOptions=sharedOptions tableId="light-table"}}`);
 
@@ -195,7 +195,7 @@ module('Integration | Component | lt body', function(hooks) {
 
   test('scaffolding', async function(assert) {
     const users = this.server.createList('user', 1);
-    this.set('table', new Table(Columns, users));
+    this.set('table', Table.create({ columns: Columns, rows: users }));
 
     await render(hbs `{{lt-body table=table sharedOptions=sharedOptions enableScaffolding=true tableId="light-table"}}`);
 
@@ -218,7 +218,7 @@ module('Integration | Component | lt body', function(hooks) {
   });
 
   test('overwrite', async function(assert) {
-    this.set('table', new Table(Columns, this.server.createList('user', 5)));
+    this.set('table', Table.create({ columns: Columns, rows: this.server.createList('user', 5) }));
 
     await render(hbs `
       {{#lt-body table=table sharedOptions=sharedOptions overwrite=true tableId="light-table" as |columns rows|}}

--- a/tests/integration/components/lt-head-test.js
+++ b/tests/integration/components/lt-head-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | lt head', function(hooks) {
   });
 
   test('render columns', async function(assert) {
-    this.set('table', new Table(Columns));
+    this.set('table', Table.create({ columns: Columns }));
 
     await render(hbs`{{lt-head table=table renderInPlace=true}}`);
 
@@ -25,7 +25,7 @@ module('Integration | Component | lt head', function(hooks) {
   });
 
   test('render grouped columns', async function(assert) {
-    this.set('table', new Table(GroupedColumns));
+    this.set('table', Table.create({ columns: GroupedColumns }));
 
     await render(hbs`{{lt-head table=table renderInPlace=true}}`);
 
@@ -36,7 +36,7 @@ module('Integration | Component | lt head', function(hooks) {
   });
 
   test('click - non-sortable column', async function(assert) {
-    this.set('table', new Table(Columns));
+    this.set('table', Table.create({ columns: Columns }));
     this.set('onColumnClick', (column) => {
       assert.ok(column);
       assert.notOk(column.sortable);
@@ -51,7 +51,7 @@ module('Integration | Component | lt head', function(hooks) {
   });
 
   test('click - sortable column', async function(assert) {
-    this.set('table', new Table(Columns));
+    this.set('table', Table.create({ columns: Columns }));
     let asc = true;
     this.set('onColumnClick', (column) => {
       assert.ok(column);
@@ -71,7 +71,7 @@ module('Integration | Component | lt head', function(hooks) {
   });
 
   test('render sort icons', async function(assert) {
-    this.set('table', new Table(Columns));
+    this.set('table', Table.create({ columns: Columns }));
 
     await render(
       hbs`{{lt-head table=table renderInPlace=true iconSortable='fa-sort' iconAscending='fa-sort-asc' iconDescending='fa-sort-desc'}}`
@@ -117,7 +117,7 @@ module('Integration | Component | lt head', function(hooks) {
       iconAscending,
       iconDescending,
       iconComponent,
-      table: new Table(Columns)
+      table: Table.create({ columns: Columns })
     });
     this.owner.register(`component:${iconComponent}`, Component.extend({
       init() {
@@ -137,7 +137,7 @@ module('Integration | Component | lt head', function(hooks) {
   test('double click', async function(assert) {
     assert.expect(4);
 
-    this.set('table', new Table(Columns));
+    this.set('table', Table.create({ columns: Columns }));
     this.set('onColumnDoubleClick', (column) => {
       assert.ok(column);
       assert.notOk(column.sortable);

--- a/tests/unit/classes/column-test.js
+++ b/tests/unit/classes/column-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Classes | Column', function() {
   test('create column - default options', function(assert) {
-    let col = new Column();
+    let col = Column.create();
     assert.ok(col);
     assert.equal(col.hidden, false);
     assert.equal(col.ascending, true);
@@ -18,34 +18,24 @@ module('Unit | Classes | Column', function() {
     assert.equal(col.width, null);
   });
 
-  test('create column - column instance', function(assert) {
-    let col = new Column({ label: 'Name' });
-    let col2 = new Column(col);
-    assert.ok(col);
-    assert.ok(col2);
-    assert.equal(col, col2);
-    assert.equal(col.label, 'Name');
-    assert.equal(col2.label, 'Name');
-  });
-
   test('reopen colum', function(assert) {
     assert.equal(typeof Column.reopen, 'function', 'reopen is a function');
     assert.equal(typeof Column.reopenClass, 'function', 'reopenClass is a function');
   });
 
   test('CP - isGroupColumn', function(assert) {
-    let col = new Column();
+    let col = Column.create();
     assert.ok(col);
     assert.deepEqual(col.subColumns, []);
     assert.equal(col.get('isGroupColumn'), false);
 
-    col.set('subColumns', [new Column()]);
+    col.set('subColumns', [Column.create()]);
     assert.equal(col.subColumns.length, 1);
     assert.equal(col.get('isGroupColumn'), true);
   });
 
   test('CP - isVisibleGroupColumn', function(assert) {
-    let col = new Column({
+    let col = Column.create({
       subColumns: [{}, {}]
     });
     assert.ok(col);
@@ -63,7 +53,7 @@ module('Unit | Classes | Column', function() {
   });
 
   test('CP - visibleSubColumns', function(assert) {
-    let col = new Column({
+    let col = Column.create({
       subColumns: [{}, {}]
     });
     assert.ok(col);
@@ -78,7 +68,7 @@ module('Unit | Classes | Column', function() {
   });
 
   test('subColumns / parent', function(assert) {
-    let col = new Column({
+    let col = Column.create({
       subColumns: [{}]
     });
     assert.ok(col);

--- a/tests/unit/classes/row-test.js
+++ b/tests/unit/classes/row-test.js
@@ -3,20 +3,10 @@ import { module, test } from 'qunit';
 
 module('Unit | Classes | Row', function() {
   test('create row - default options', function(assert) {
-    let row = new Row();
+    let row = Row.create();
     assert.ok(row);
     assert.equal(row.expanded, false);
     assert.equal(row.selected, false);
-  });
-
-  test('create row - row instance', function(assert) {
-    let row = new Row({ foo: 'bar' });
-    let row2 = new Row(row);
-    assert.ok(row);
-    assert.ok(row2);
-    assert.equal(row, row2);
-    assert.equal(row.get('foo'), 'bar');
-    assert.equal(row2.get('foo'), 'bar');
   });
 
   test('reopen row', function(assert) {

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -6,7 +6,7 @@ import EmberObject from '@ember/object';
 
 module('Unit | Classes | Table', function() {
   test('create table - default options', function(assert) {
-    let table = new Table();
+    let table = Table.create();
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -14,7 +14,7 @@ module('Unit | Classes | Table', function() {
   });
 
   test('create table - with options', function(assert) {
-    let table = new Table([{}, {}], [{}]);
+    let table = Table.create({ columns: [{}, {}], rows: [{}] });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 1);
@@ -28,10 +28,10 @@ module('Unit | Classes | Table', function() {
     assert.expect(2);
 
     assert.throws(() => {
-      new Table([{}, {}], null);
+      Table.create({ columns: [{}, {}], rows: null });
     }, /\[ember-light-table] rows must be an array if defined/, 'rows is not an array');
     assert.throws(() => {
-      new Table(null, [{}]);
+      Table.create({ columns: null, rows: [{}] });
     }, /\[ember-light-table] columns must be an array if defined/, 'columns is not an array');
   });
 
@@ -50,7 +50,7 @@ module('Unit | Classes | Table', function() {
     });
 
     let columns = [{ label: 'Name', valuePath: 'name' }];
-    let table = new Table(columns, rows);
+    let table = Table.create({ columns, rows });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 3);
@@ -63,9 +63,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('CP - visibleColumnGroups', function(assert) {
-    let table = new Table();
-    let col = new Column();
-    let group = new Column({
+    let table = Table.create();
+    let col = Column.create();
+    let group = Column.create({
       subColumns: [{}, {}]
     });
 
@@ -80,11 +80,11 @@ module('Unit | Classes | Table', function() {
   });
 
   test('CP - visibleSubColumns', function(assert) {
-    let table = new Table();
-    let group = new Column({
+    let table = Table.create();
+    let group = Column.create({
       subColumns: [{}, {}]
     });
-    let group2 = new Column({
+    let group2 = Column.create({
       subColumns: [{}, {}]
     });
 
@@ -96,12 +96,12 @@ module('Unit | Classes | Table', function() {
   });
 
   test('CP - allColumns', function(assert) {
-    let table = new Table();
-    let col = new Column();
-    let group = new Column({
+    let table = Table.create();
+    let col = Column.create();
+    let group = Column.create({
       subColumns: [{}, {}]
     });
-    let group2 = new Column({
+    let group2 = Column.create({
       subColumns: [{}, {}]
     });
 
@@ -110,7 +110,7 @@ module('Unit | Classes | Table', function() {
   });
 
   test('CP - isEmpty', function(assert) {
-    let table = new Table([{}, {}], []);
+    let table = Table.create({ columns: [{}, {}], rows: [] });
 
     assert.ok(table, 'table is set up correctly');
     assert.ok(table.get('isEmpty'), 'table is initially empty');
@@ -122,7 +122,7 @@ module('Unit | Classes | Table', function() {
 
   test('CP - isEmpty (enableSync = true)', function(assert) {
     let rowsArray = emberArray();
-    let table = new Table([{}, {}], rowsArray, { enableSync: true });
+    let table = Table.create({ columns: [{}, {}], rows: rowsArray, enableSync: true });
 
     assert.ok(table, 'table is set up correctly');
     assert.ok(table.get('isEmpty'), 'table is initially empty');
@@ -133,7 +133,7 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - setRows', function(assert) {
-    let table = new Table();
+    let table = Table.create();
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -147,9 +147,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - addRow', function(assert) {
-    let table = new Table();
+    let table = Table.create();
     let content = { name: 'Offir' };
-    let row = new Row(content);
+    let row = Row.create({ content });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -171,9 +171,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - addRows', function(assert) {
-    let table = new Table();
+    let table = Table.create();
     let content = { name: 'Offir' };
-    let row = new Row(content);
+    let row = Row.create({ content });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -195,9 +195,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - pushRow', function(assert) {
-    let table = new Table();
+    let table = Table.create();
     let content = { name: 'Offir' };
-    let row = new Row(content);
+    let row = Row.create({ content });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -219,9 +219,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - pushRows', function(assert) {
-    let table = new Table();
+    let table = Table.create();
     let content = { name: 'Offir' };
-    let row = new Row(content);
+    let row = Row.create({ content });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -243,7 +243,7 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - insertRowAt', function(assert) {
-    let table = new Table();
+    let table = Table.create();
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -259,9 +259,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - removeRow', function(assert) {
-    let table = new Table();
+    let table = Table.create();
     let content = { name: 'Offir' };
-    let row = new Row(content);
+    let row = Row.create({ content });
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -282,13 +282,15 @@ module('Unit | Classes | Table', function() {
     assert.equal(table.get('rows.length'), 3);
 
     table.removeRow(content);
+    // I believe this fails because our content object is duplicated at some point during the set process
+    // if this is an issue we'll need to find a different way to reliably identify duplicates
     assert.equal(table.get('rows.length'), 0);
   });
 
   test('table method - removeRows', function(assert) {
-    let table = new Table();
-    let row = new Row();
-    let row2 = new Row();
+    let table = Table.create();
+    let row = Row.create();
+    let row2 = Row.create();
 
     assert.ok(table);
     assert.equal(table.get('rows.length'), 0);
@@ -301,7 +303,7 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - setColumns', function(assert) {
-    let table = new Table();
+    let table = Table.create();
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -314,8 +316,8 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - addColumn', function(assert) {
-    let table = new Table();
-    let col = new Column({ label: 'Name' });
+    let table = Table.create();
+    let col = Column.create({ label: 'Name' });
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -333,8 +335,8 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - addColumns', function(assert) {
-    let table = new Table();
-    let col = new Column({ label: 'Name' });
+    let table = Table.create();
+    let col = Column.create({ label: 'Name' });
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -352,9 +354,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - pushColumn', function(assert) {
-    let table = new Table();
+    let table = Table.create();
     let content = { label: 'Name' };
-    let col = new Column(content);
+    let col = Column.create(content);
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -375,8 +377,8 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - pushColumns', function(assert) {
-    let table = new Table();
-    let col = new Column({ label: 'Name' });
+    let table = Table.create();
+    let col = Column.create({ label: 'Name' });
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -394,7 +396,7 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - insertColumnAt', function(assert) {
-    let table = new Table();
+    let table = Table.create();
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -409,8 +411,8 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - removeColumn', function(assert) {
-    let table = new Table();
-    let col = new Column({ label: 'Name' });
+    let table = Table.create();
+    let col = Column.create({ label: 'Name' });
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -429,9 +431,9 @@ module('Unit | Classes | Table', function() {
   });
 
   test('table method - removeColumns', function(assert) {
-    let table = new Table();
-    let col = new Column();
-    let col2 = new Column();
+    let table = Table.create();
+    let col = Column.create();
+    let col2 = Column.create();
 
     assert.ok(table);
     assert.equal(table.get('columns.length'), 0);
@@ -471,7 +473,7 @@ module('Unit | Classes | Table', function() {
 
   test('table modifications with sync enabled - simple', function(assert) {
     let rows = emberArray([]);
-    let table = new Table([], rows, { enableSync: true });
+    let table = Table.create({ columns: [], rows, enableSync: true });
 
     table.addRow({ firstName: 'Offir' });
 
@@ -493,7 +495,7 @@ module('Unit | Classes | Table', function() {
 
   test('table modifications with sync enabled - stress', function(assert) {
     let rows = emberArray([]);
-    let table = new Table([], rows, { enableSync: true });
+    let table = Table.create({ columns: [], rows, enableSync: true });
 
     for (let i = 0; i < 100; i++) {
       table.addRow({ position: i });
@@ -531,7 +533,7 @@ module('Unit | Classes | Table', function() {
 
   test('table modifications with sync enabled - sort', function(assert) {
     let rows = emberArray([]);
-    let table = new Table([], rows, { enableSync: true });
+    let table = Table.create({ columns: [], rows, enableSync: true });
     let length = 5;
 
     for (let i = 0; i < length; i++) {
@@ -559,7 +561,7 @@ module('Unit | Classes | Table', function() {
   test('setRowsSynced', function(assert) {
     let initialRows = emberArray([]);
     let otherRows = emberArray([]);
-    let table = new Table([], initialRows, { enableSync: true });
+    let table = Table.create({ columns: [], rows: initialRows, enableSync: true });
     let initialLength = 5;
     let otherLength = 13;
 

--- a/tests/unit/utils/fix-proto-test.js
+++ b/tests/unit/utils/fix-proto-test.js
@@ -25,7 +25,7 @@ module('Unit | Utility | fix proto', function() {
         return true;
       }
     });
-    let instance = new DerivedClass();
+    let instance = DerivedClass.create();
     assert.ok(instance.someMethod(), 'reopen works');
   });
 });


### PR DESCRIPTION
This is a breaking change as it converts the new Class() syntax to Class.create().
In addition, the only way I could get these to work was to convert the positional arguments to named args in an options hashes:

`new Table(columns, rows)` => `Table.create(columns: columns, rows: rows)`
`new Row(content, options)` => `Row.create({ content: content })`
`new Column(opts)` => `Column.create(opts)`

We’ve had to replace the native constructor methods with emberObject init methods as per the official docs which should also fix #699. As a result we’ve removed the Ember 2.12 ‘hacks’ which shouldn’t be an issue as we’ve bumped ember version minimum version to 2.18.

Clearly there are issues with ember 2.18 that need resolving but @alexander-alvarez what are your thoughts so far?