### PR TITLE
BREAKING drop support for ember 2.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-lts-3.4
     - EMBER_TRY_SCENARIO=ember-lts-3.8
     - EMBER_TRY_SCENARIO=ember-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-beta
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
 </div>
 
-[![Ember Versions](https://img.shields.io/badge/Ember.js%20Versions-%5E2.18%20and%20%5E3.0-brightgreen.svg)](https://travis-ci.org/offirgolan/ember-light-table)
+[![Ember Versions](https://img.shields.io/badge/Ember.js%20Versions-%5E3.4%20and%20%5E4.0-brightgreen.svg)](https://travis-ci.org/offirgolan/ember-light-table)
 [![Build Status](https://travis-ci.org/offirgolan/ember-light-table.svg)](https://travis-ci.org/offirgolan/ember-light-table)
 [![npm version](https://badge.fury.io/js/ember-light-table.svg)](http://badge.fury.io/js/ember-light-table)
 [![Download Total](https://img.shields.io/npm/dt/ember-light-table.svg)](http://badge.fury.io/js/ember-light-table)
@@ -36,8 +36,8 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v2.18 or above
-* Ember CLI v2.18 or above
+* Ember.js v3.4 or above
+* Ember CLI v3.4 or above
 
 
 Installation

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,14 +12,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.18',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.18.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-3.4',
           npm: {
             devDependencies: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-light-table",
   "version": "2.0.0-beta.3",
-  "description": "Lightweight, component based table for Ember 2.18+",
+  "description": "Lightweight, component based table for Ember 3.4+",
   "keywords": [
     "ember-addon",
     "table"
@@ -95,7 +95,7 @@
     "configPath": "tests/dummy/config",
     "demoURL": "http://offirgolan.github.io/ember-light-table",
     "versionCompatibility": {
-      "ember": ">=2.18.0 <4.0.0"
+      "ember": ">=3.4.0 <4.0.0"
     }
   },
   "changelog": {


### PR DESCRIPTION
See #701 for more info - essentially the change in the API back to conventional EmberObject initialization has issues with ember 2.18. Whilst I'm sure these could be resolved it's holding up releasing #701 which is essential for newer versions (ember 3.11+) of Ember. 

If there is a strong backlash to this change on 2-x branch then we can look to restoring support - otherwise those using ember <3.4 should stick with the master branch.