### PR TITLE
Replace volatile computed properties

### DIFF
--- a/addon/components/lt-column-resizer.js
+++ b/addon/components/lt-column-resizer.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { get } from '@ember/object';
 import closest from 'ember-light-table/utils/closest';
 import layout from '../templates/components/lt-column-resizer';
 
@@ -15,9 +15,9 @@ export default Component.extend({
   startWidth: null,
   startX: null,
 
-  colElement: computed(function() {
-    return this.get('element').parentNode;
-  }).volatile().readOnly(),
+  colElement() {
+    return get(this, 'element').parentNode;
+  },
 
   didInsertElement() {
     this._super(...arguments);
@@ -44,7 +44,7 @@ export default Component.extend({
   },
 
   mouseDown(e) {
-    let column = this.get('colElement');
+    let column = this.colElement();
 
     e.preventDefault();
     e.stopPropagation();
@@ -64,7 +64,7 @@ export default Component.extend({
       e.preventDefault();
       e.stopPropagation();
 
-      let column = this.get('colElement');
+      let column = this.colElement();
       let width = `${column.offsetWidth}px`;
 
       this.set('isResizing', false);
@@ -86,7 +86,7 @@ export default Component.extend({
       let { startX, startWidth } = this.getProperties(['startX', 'startWidth']);
       let width = `${Math.max(startWidth + (e.pageX - startX), minResizeWidth)}px`;
 
-      let column = this.get('colElement');
+      let column = this.colElement();
       let index = this.get('table.visibleColumns').indexOf(this.get('column')) + 1;
       let table = closest(this.get('element'), TOP_LEVEL_CLASS);
 

--- a/addon/mixins/draggable-column.js
+++ b/addon/mixins/draggable-column.js
@@ -1,5 +1,5 @@
 import Mixin from '@ember/object/mixin';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { run } from '@ember/runloop';
 
 let sourceColumn;
@@ -36,13 +36,13 @@ export default Mixin.create({
     return parent ? parent.get('subColumns') : this.get('table.columns');
   }).readOnly(),
 
-  isDropTarget: computed(function() {
-    let column = this.get('column');
+  isDropTarget() {
+    let column = get(this, 'column');
     /*
      A column is a valid drop target only if its in the same group
      */
     return sourceColumn && column.get('droppable') && column.get('parent') === sourceColumn.get('parent');
-  }).volatile().readOnly(),
+  },
 
   dragStart(e) {
     this._super(...arguments);
@@ -70,7 +70,7 @@ export default Mixin.create({
   dragEnter(e) {
     this._super(...arguments);
 
-    if (this.get('isDropTarget')) {
+    if (this.isDropTarget()) {
       e.preventDefault();
       this.set('isDragTarget', this.get('column') !== sourceColumn);
     }
@@ -79,7 +79,7 @@ export default Mixin.create({
   dragOver(e) {
     this._super(...arguments);
 
-    if (this.get('isDropTarget')) {
+    if (this.isDropTarget()) {
       e.preventDefault();
       /*
         NOTE: dragLeave will be triggered by any child elements inside the


### PR DESCRIPTION
This fixes Ember 3.9 deprecation for volatile computed properties.