### PR TITLE
bump ember-composable-helpers - array helper conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-babel": "^7.10.0",
     "ember-cli-htmlbars": "^3.1.0",
     "ember-cli-string-helpers": "^4.0.0",
-    "ember-composable-helpers": "^2.0.0",
+    "ember-composable-helpers": "^3.1.1",
     "ember-get-config": "^0.2.4",
     "ember-in-viewport": "^3.5.8",
     "ember-scrollable": "^1.0.0",


### PR DESCRIPTION
`ember-composable-helpers` < 3.x defines a custom `array` helpers. Since ember version 3.8.0, ember provides this helper out of the box. Upgrading our project's ember version from 3.16.4 to 3.17.1 somehow brings up this conflict.
```
Error: Assertion Failed: You attempted to overwrite the built-in helper "array" which is not allowed. Please rename the helper.
```
Bumping `ember-composable-helpers`  to a version that no longer contains this helper, solves the issue.
References:
- [PR removing array helper](https://github.com/DockYard/ember-composable-helpers/pull/321)
- [recent Stackoverflow issue](https://stackoverflow.com/questions/60746799/error-you-attempted-to-overwrite-the-built-in-helper-array-where-is-this-com)