### PR TITLE
Fix deprecation warning for overridden rowspan computed property

### DIFF
--- a/addon/components/columns/base.js
+++ b/addon/components/columns/base.js
@@ -104,9 +104,19 @@ const Column = Component.extend(DraggableColumnMixin, {
    * @property rowspan
    * @type {Number}
    */
-  rowspan: computed('column.visibleSubColumns.[]', function() {
-    let subColumns = this.get('column.visibleSubColumns');
-    return !isEmpty(subColumns) ? 1 : 2;
+  rowspan: computed('column.visibleSubColumns.[]', {
+    get() {
+      if (this._rowspan) {
+        return this._rowspan;
+      }
+
+      let subColumns = this.get('column.visibleSubColumns');
+      return !isEmpty(subColumns) ? 1 : 2;
+    },
+
+    set(key, value) {
+      return this._rowspan = value;
+    }
   })
 });
 


### PR DESCRIPTION
This maintains existing behaviour whilst removing the deprecation warning.