### PR TITLE
fix: add setter for cell `value` CP for Ember 4 strict-mode

### DIFF
--- a/addon/components/cells/base.hbs
+++ b/addon/components/cells/base.hbs
@@ -1,4 +1,50 @@
-{{#if this.column.cellComponent}}
+{{!--
+
+  XXX @Phorest Changes:
+
+  1. we are passing rowIndex to the cell component
+  2. we have custom "editable" components
+
+--}}
+
+{{! template-lint-disable no-unnecessary-component-helper}}
+{{#if (or (eq this.column.editable.type "TEXT") (eq this.column.editable.type "NUMBER"))}}
+  {{component
+    "ui-table/inline-editing/editable-input"
+    tableActions=this.tableActions
+    extra=this.extra
+    table=this.table
+    column=this.column
+    row=this.row
+    value=this.value
+    rawValue=this.rawValue
+    editableConfig=this.column.editable
+  }}
+{{else if (eq this.column.editable.type "SELECT")}}
+  {{component
+    "ui-table/inline-editing/editable-select"
+    tableActions=this.tableActions
+    extra=this.extra
+    table=this.table
+    column=this.column
+    row=this.row
+    value=this.value
+    rawValue=this.rawValue
+    editableConfig=this.column.editable
+  }}
+{{else if (eq this.column.editable.type "PASSWORD")}}
+  {{component
+    "ui-table/inline-editing/editable-password"
+    tableActions=this.tableActions
+    extra=this.extra
+    table=this.table
+    column=this.column
+    row=this.row
+    value=this.value
+    rawValue=this.rawValue
+    editableConfig=this.column.editable
+  }}
+{{else if this.column.cellComponent}}
   {{component
     (ensure-safe-component this.column.cellComponent)
     tableActions=this.tableActions
@@ -8,7 +54,8 @@
     row=this.row
     value=this.value
     rawValue=this.rawValue
+    rowIndex=this.rowIndex
   }}
 {{else}}
-  {{this.value}}
+  {{~this.value~}}
 {{/if}}

--- a/addon/components/cells/base.js
+++ b/addon/components/cells/base.js
@@ -81,14 +81,26 @@ export default Component.extend({
    * @property value
    * @type {Mixed}
    */
-  value: computed('column.format', 'rawValue', function () {
-    let rawValue = this.rawValue;
-    let format = this.column.format;
+  value: computed('column.format', 'rawValue', {
+    get() {
+      let rawValue = this.rawValue;
+      let format = this.column.format;
 
-    if (format && typeof format === 'function') {
-      return format.call(this, rawValue);
-    }
+      if (format && typeof format === 'function') {
+        return format.call(this, rawValue);
+      }
 
-    return rawValue;
+      return rawValue;
+    },
+    // Ember 4 strict-mode rejects writes to computed properties that don't
+    // declare a setter. The cell template (cells/base.hbs) passes
+    // `value=this.value` into a child component (e.g. an editable input or
+    // a custom cell), and when that child writes back the framework tries
+    // to update this slot. Provide a setter that records the override; the
+    // cached value is invalidated again whenever rawValue or column.format
+    // change.
+    set(_key, newValue) {
+      return newValue;
+    },
   }),
 });

--- a/addon/components/columns/base.hbs
+++ b/addon/components/columns/base.hbs
@@ -1,3 +1,13 @@
+{{!--
+
+  XXX @Phorest Changes:
+
+  1. We've changed the order of {{label}} and sortIcons. We prefer to have the label before sortIcons.
+  2. To make it easier to style we wrapped {{label}} with <span> (because the text node cannot be styled),
+  and wrapped that span and sortIcons with a <div>.
+
+--}}
+
 {{#if this.column.component}}
   {{component
     (ensure-safe-component this.column.component)
@@ -8,16 +18,21 @@
     sortIcons=this.sortIcons
   }}
 {{else}}
-  {{#if (and this.sortIcons.iconComponent this.sortIconProperty)}}
-    {{component
-      (ensure-safe-component this.sortIcons.iconComponent)
-      sortIcons=this.sortIcons
-      sortIconProperty=this.sortIconProperty
-    }}
-  {{else if this.sortIconProperty}}
-    <i class='lt-sort-icon {{get this.sortIcons this.sortIconProperty}}'></i>
-  {{/if}}
-  {{this.label}}
+  <div>
+    <span>
+      {{this.label}}
+    </span>
+
+    {{#if (and this.sortIcons.iconComponent this.sortIconProperty)}}
+      {{component
+        (ensure-safe-component this.sortIcons.iconComponent)
+        sortIcons=this.sortIcons
+        sortIconProperty=this.sortIconProperty
+      }}
+    {{else if this.sortIconProperty}}
+      <i class='lt-sort-icon {{get this.sortIcons this.sortIconProperty}}'></i>
+    {{/if}}
+  </div>
 {{/if}}
 
 {{#if this.isResizable}}

--- a/addon/components/lt-body.hbs
+++ b/addon/components/lt-body.hbs
@@ -1,3 +1,12 @@
+{{!--
+
+  XXX @Phorest Changes:
+
+  1. we are passing rowIndex when iterating through rows (please notice we use "light-table/lt-row" as lt.row to scope it)
+  2. we allow passing scrollableContent (further explanation below)
+
+--}}
+
 <div
   class="lt-body-wrap
   {{if this.canSelect "can-select"}}
@@ -41,7 +50,7 @@
                 firstVisibleChanged=(action "firstVisibleChanged")
                 lastVisibleChanged=(action "lastVisibleChanged")
                 firstReached=(action "firstReached")
-                lastReached=(action "lastReached") as |row|
+                lastReached=(action "lastReached") as |row rowIndex|
               }}
                 {{lt.row
                   row=row
@@ -53,6 +62,7 @@
                   enableScaffolding=this.enableScaffolding
                   canExpand=this.canExpand
                   canSelect=this.canSelect
+                  rowIndex=rowIndex
                   click=(action "onRowClick" row)
                   doubleClick=(action "onRowDoubleClick" row)
                 }}
@@ -118,7 +128,7 @@
               {{#each
                 (if
                   scrollbar (compute scrollbar.update this.rows) this.rows
-                ) as |row|
+                ) as |row rowIndex|
               }}
                 {{lt.row
                   row=row
@@ -130,6 +140,7 @@
                   enableScaffolding=this.enableScaffolding
                   canExpand=this.canExpand
                   canSelect=this.canSelect
+                  rowIndex=rowIndex
                   click=(action "onRowClick" row)
                   doubleClick=(action "onRowDoubleClick" row)
                 }}
@@ -177,10 +188,26 @@
         </table>
 
         {{#if @onScrolledToBottom}}
+          {{!--
+            The only thing in this layout that has changed is an additional option
+            to pass scrollableContent parameter from the outside.
+
+            That let us using infinite scroll without a need to use fixed header provided by `ember-light-table` that
+            also requires to render the table in a container that has some height set.
+
+            We can then use a different DOM element as a scrollable container than the default one.
+
+            Diff:
+            - scrollableContent=(concat "#" tableId " .lt-scrollable")}}
+            + scrollableContent=(or scrollableContent (concat "#" tableId " .lt-scrollable"))}}
+          --}}
           <lt.infinity
             @enterViewport={{this.enterViewport}}
             @exitViewport={{this.exitViewport}}
-            @scrollableContent={{concat "#" this.tableId " .lt-scrollable"}}
+            @scrollableContent={{or
+              this.scrollableContent
+              (concat "#" this.tableId " .lt-scrollable")
+            }}
           />
         {{/if}}
 

--- a/addon/components/lt-row.hbs
+++ b/addon/components/lt-row.hbs
@@ -1,3 +1,11 @@
+{{!--
+
+  XXX @Phorest Changes:
+
+  1. add "rowIndex" here
+
+--}}
+
 {{#each this.columns as |column|}}
   {{component
     (concat 'light-table/cells/' column.cellType)
@@ -7,5 +15,6 @@
     rawValue=(get this.row column.valuePath)
     tableActions=this.tableActions
     extra=this.extra
+    rowIndex=@rowIndex
   }}
 {{/each}}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@embroider/util": "^1.9.0",
-    "@fortawesome/ember-fontawesome": "^0.2.2",
+    "@fortawesome/ember-fontawesome": "^1.0.3",
     "@fortawesome/free-brands-svg-icons": "^5.15.2",
     "@fortawesome/free-regular-svg-icons": "^5.15.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
@@ -99,6 +99,9 @@
     "release-it-lerna-changelog": "^5.0.0",
     "sass": "^1.57.1",
     "webpack": "^5.75.0"
+  },
+  "resolutions": {
+    "rollup": "2.78.0"
   },
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,47 +1224,47 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@ember-data/adapter@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.28.10.tgz#ca46a124b19096a0be6940c008f1e6cf7d653d36"
-  integrity sha512-/ocqzP2dPw/wTUMiE0A5YE5lUvUVLslnKCTQYLCmgKYhBaKihAiyhrug2XXHsUsi065GODuY9tpt2YO+mGiotQ==
+"@ember-data/adapter@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.28.13.tgz#3b921365046a329f3eb1c72fc4964c6aff06e53b"
+  integrity sha512-AwLJTs+GvxX72vfP3edV0hoMLD9oPWJNbnqxakXVN9xGTuk6/TeGQLMrVU3222GCoMMNrJ357Nip7kZeFo4IdA==
   dependencies:
-    "@ember-data/private-build-infra" "3.28.10"
-    "@ember-data/store" "3.28.10"
+    "@ember-data/private-build-infra" "3.28.13"
+    "@ember-data/store" "3.28.13"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^4.1.0"
 
-"@ember-data/canary-features@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.28.10.tgz#860602536ca2ee526f7bffa9e9ccdf6686a259b8"
-  integrity sha512-QaRMNSzsH1XvwCKyCXlimZhVSYAcs1x42cBemaiRMg5/LDrDZKMhWbFTNomM/k+0D2a0zHsCO91FXG8m1K19qQ==
+"@ember-data/canary-features@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.28.13.tgz#59cd75b94bfff86f85affb42e66016c71f45f02e"
+  integrity sha512-fgpcB0wmtUjZeqcIKkfP/MclQjY5r8ft8YZhPlvQh2MIx+3d3nCNRXB6lEUdRdQphFEag2towONFEIsiOAgs3Q==
   dependencies:
     ember-cli-babel "^7.26.6"
     ember-cli-typescript "^4.1.0"
 
-"@ember-data/debug@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.28.10.tgz#a5d680a7ef9dccfc23c088f8b91d420e7d3a8d89"
-  integrity sha512-smR2X8J0jycq5i3og0nFrYEEbwxjUPcXJ75tlAz9Rahqxz6U3UWAv29TKBNVUFeDQvJuOvdLzcfLK9YZ9i9bxQ==
+"@ember-data/debug@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.28.13.tgz#eb20779de83429f5d493d3c8e81ced468fa5974d"
+  integrity sha512-ofny/Grpqx1lM6KWy5q75/b2/B+zQ4B4Ynk7SrQ//sFvpX3gjuP8iN07SKTHSN07vedlC+7QNhNJdCQwyqK1Fg==
   dependencies:
-    "@ember-data/private-build-infra" "3.28.10"
+    "@ember-data/private-build-infra" "3.28.13"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^4.1.0"
 
-"@ember-data/model@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.28.10.tgz#a1890bc69bfc6aac33ed4c37834810984a8f3c66"
-  integrity sha512-k72fqbKjSSmDHLGr0U/kHRsFI7gamN2nMGs0Qh1c2ZPR7CLXaNUCOQnJ/itxRInTX8WO996hjMUB+IMiKqfwYQ==
+"@ember-data/model@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.28.13.tgz#50ac1bd5783e7cc51344767d5ff46f84198f4d1a"
+  integrity sha512-V5Hgzz5grNWTSrKGksY9xeOsTDLN/d3qsVMu26FWWHP5uqyWT0Cd4LSRpNxs14PsTFDcbrtGKaZv3YVksZfFEQ==
   dependencies:
-    "@ember-data/canary-features" "3.28.10"
-    "@ember-data/private-build-infra" "3.28.10"
-    "@ember-data/store" "3.28.10"
+    "@ember-data/canary-features" "3.28.13"
+    "@ember-data/private-build-infra" "3.28.13"
+    "@ember-data/store" "3.28.13"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
     ember-cached-decorator-polyfill "^0.1.4"
@@ -1275,13 +1275,13 @@
     ember-compatibility-helpers "^1.2.0"
     inflection "~1.13.1"
 
-"@ember-data/private-build-infra@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.28.10.tgz#ba4f764a54bbb7d62822a24adbd2a1b976fbec7c"
-  integrity sha512-Fd9n2SOsndFOuDISkYQZsWRkif8gu0UG/1Yvloy3eOAPNLJBbGovZOFRgO4bxcPg3iHUl6THbYSLl/rXYv/Xiw==
+"@ember-data/private-build-infra@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.28.13.tgz#828a27e724240b1ef70ae5dd8ab8be1f61275929"
+  integrity sha512-8gT3/gnmbNgFIMVdHBpl3xFGJefJE26VUIidFHTF1/N1aumVUlEhnXH0BSPxvxTnFXz/klGSTOMs+sDsx3jw6A==
   dependencies:
     "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.28.10"
+    "@ember-data/canary-features" "3.28.13"
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
@@ -1307,14 +1307,14 @@
     semver "^7.1.3"
     silent-error "^1.1.1"
 
-"@ember-data/record-data@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.28.10.tgz#af90e8b81f32253970f6c276b2f1988097138456"
-  integrity sha512-LYAAAlN6EgZFAXAzmyDlnnhQjgVnjA127y3EV1aRJR0xzjDfk5rFU2lsPM4D/ClKKBWN5WwiQRBb9ljyzCP7xw==
+"@ember-data/record-data@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.28.13.tgz#2bf169404732e126489d3b3a8dc6c0dfca8b5f5f"
+  integrity sha512-0qYOxQr901eZ0JoYVt/IiszZYuNefqO6yiwKw0VH2dmWhVniQSp+Da9YnoKN9U2KgR4NdxKiUs2j9ZLNZ+bH7g==
   dependencies:
-    "@ember-data/canary-features" "3.28.10"
-    "@ember-data/private-build-infra" "3.28.10"
-    "@ember-data/store" "3.28.10"
+    "@ember-data/canary-features" "3.28.13"
+    "@ember-data/private-build-infra" "3.28.13"
+    "@ember-data/store" "3.28.13"
     "@ember/edition-utils" "^1.2.0"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
@@ -1325,24 +1325,24 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-data/serializer@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.28.10.tgz#4b560dbdd6ba43f8576e4cae59c67ca77639bdee"
-  integrity sha512-HJa5gSigSaBHd+4mmbbKUe3Y2GlfThbC+RP5hJ/K9feo1ckBhAVbkM1q523RYdvqHLV+cpDX5irt9A2WGmGjWw==
+"@ember-data/serializer@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.28.13.tgz#6dfa8ba17c0ea192313134643dbe56adf45a722a"
+  integrity sha512-BlYXi8ObH0B5G7QeWtkf9u8PrhdlfAxOAsOuOPZPCTzWsQlmyzV6M9KvBmIAvJtM2IQ3a5BX2o71eP6/7MJDUg==
   dependencies:
-    "@ember-data/private-build-infra" "3.28.10"
-    "@ember-data/store" "3.28.10"
+    "@ember-data/private-build-infra" "3.28.13"
+    "@ember-data/store" "3.28.13"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^4.1.0"
 
-"@ember-data/store@3.28.10":
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.28.10.tgz#023ae0a821efc23f712b543d5df0e3077739a914"
-  integrity sha512-GmAHKZJnBuAIfczrLKUCMGz3kWdMAfKjVgWH6jFHekWPypMMDFgiSeSotYi1l49uIgKcgzEKoV1iCYHUz2+1mA==
+"@ember-data/store@3.28.13":
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.28.13.tgz#be3c3fca03d155767af72422f6a3c6dcd6147be8"
+  integrity sha512-y1ddWLfR20l3NN9fNfIAFWCmREnC6hjKCZERDgkvBgZOCAKcs+6bVJGyMmKBcsp4W7kanqKn71tX7Y63jp+jXQ==
   dependencies:
-    "@ember-data/canary-features" "3.28.10"
-    "@ember-data/private-build-infra" "3.28.10"
+    "@ember-data/canary-features" "3.28.13"
+    "@ember-data/private-build-infra" "3.28.13"
     "@ember/string" "^3.0.0"
     "@glimmer/tracking" "^1.0.4"
     ember-cached-decorator-polyfill "^0.1.4"
@@ -1552,42 +1552,43 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
   integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
 
-"@fortawesome/ember-fontawesome@^0.2.2":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@fortawesome/ember-fontawesome/-/ember-fontawesome-0.2.3.tgz#62d943d0771b8fe291aaed7a8a223c8d7d8b6f02"
-  integrity sha512-wRiP0k1D7J3ecQhrsGpg+j7PbrFOQtDsMuAUYpvbrh+hSmfO0TCbL/BkPRMtgUIvtJiIigomvQKsiGvPJsfSeQ==
+"@fortawesome/ember-fontawesome@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/ember-fontawesome/-/ember-fontawesome-1.0.3.tgz#d315712cb5fc9dd03e3ba40faa98d0d8c2ba203a"
+  integrity sha512-KGw4a4moLo9wcGwFU05Y7yV2/va2R/lN7rO3cw6ZBrnMigyAReYH9XcK4zkiAXGaLAbzc/mOyP19ofr2rc7HBg==
   dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.0"
+    "@fortawesome/fontawesome-svg-core" "^6.2.0"
+    "@rollup/plugin-node-resolve" "^15.1.0"
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^4.2.0"
     broccoli-plugin "^4.0.3"
-    broccoli-rollup "^4.1.1"
+    broccoli-rollup "^5.0.0"
     broccoli-source "^3.0.0"
     camel-case "^4.1.1"
     ember-ast-helpers "0.3.5"
-    ember-cli-babel "^7.21.0"
-    ember-cli-htmlbars "^5.2.0"
-    ember-get-config "^0.3.0"
+    ember-auto-import "^2.3.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
+    ember-get-config "^2.0.0"
     find-yarn-workspace-root "^2.0.0"
     glob "^7.1.2"
-    rollup-plugin-node-resolve "^5.2.0"
+
+"@fortawesome/fontawesome-common-types@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz#31ab07ca6a06358c5de4d295d4711b675006163f"
+  integrity sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==
 
 "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
   integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
 
-"@fortawesome/fontawesome-common-types@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
-  integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==
-
-"@fortawesome/fontawesome-svg-core@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz#343fac91fa87daa630d26420bfedfba560f85885"
-  integrity sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==
+"@fortawesome/fontawesome-svg-core@^6.2.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz#2a24c32ef92136e98eae2ff334a27145188295ff"
+  integrity sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.3.0"
+    "@fortawesome/fontawesome-common-types" "6.6.0"
 
 "@fortawesome/free-brands-svg-icons@^5.15.2":
   version "5.15.4"
@@ -2061,6 +2062,26 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@rollup/plugin-node-resolve@^15.1.0":
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz#efbb35515c9672e541c08d59caba2eff492a55d5"
+  integrity sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    "@types/resolve" "1.20.2"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.22.1"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.3.tgz#3001bf1a03f3ad24457591f2c259c8e514e0dbdf"
+  integrity sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
+
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
@@ -2102,11 +2123,6 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
-
-"@types/broccoli-plugin@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#38f8462fecaebc4e09a32e4d4ed1b9808f75bbca"
-  integrity sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ==
 
 "@types/broccoli-plugin@^3.0.0":
   version "3.0.0"
@@ -2189,6 +2205,11 @@
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/estree@^1.0.0":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
+  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.30"
@@ -2278,12 +2299,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
-  dependencies:
-    "@types/node" "*"
+"@types/resolve@1.20.2":
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
+  integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
 "@types/rimraf@^2.0.2", "@types/rimraf@^2.0.3":
   version "2.0.5"
@@ -2475,7 +2494,7 @@ acorn-walk@^8.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^7.1.0, acorn@^7.4.0:
+acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -3400,14 +3419,6 @@ broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-broccoli-file-creator@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
-  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
-  dependencies:
-    broccoli-plugin "^1.1.0"
-    mkdirp "^0.5.1"
-
 broccoli-file-creator@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
@@ -3691,7 +3702,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^2.0.0, broccoli-plugin@^2.1.0:
+broccoli-plugin@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
   integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
@@ -3713,21 +3724,6 @@ broccoli-plugin@^3.1.0:
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
-
-broccoli-rollup@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz#7531a24d88ddab9f1bace1c6ee6e6ca74a38d36f"
-  integrity sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==
-  dependencies:
-    "@types/broccoli-plugin" "^1.3.0"
-    broccoli-plugin "^2.0.0"
-    fs-tree-diff "^2.0.1"
-    heimdalljs "^0.2.6"
-    node-modules-path "^1.0.1"
-    rollup "^1.12.0"
-    rollup-pluginutils "^2.8.1"
-    symlink-or-copy "^1.2.0"
-    walk-sync "^1.1.3"
 
 broccoli-rollup@^5.0.0:
   version "5.0.0"
@@ -3893,11 +3889,6 @@ buffer@^6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
-
-builtin-modules@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
-  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
 builtins@^5.0.0:
   version "5.0.1"
@@ -4799,6 +4790,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
@@ -5133,7 +5129,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -5711,17 +5707,17 @@ ember-concurrency@^2.3.7:
     ember-destroyable-polyfill "^2.0.2"
 
 ember-data@^3.16.0:
-  version "3.28.10"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.28.10.tgz#c8705df95b5d6067946953c73879dacb5742518d"
-  integrity sha512-6S8869S6o2iYWv2uMhMphX7WsAgvm2pA+qg1LMZX3UdMFq57BkrSuDBU43uxSbuwmKmGlzoNqVwVOtSsgBPiLg==
+  version "3.28.13"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.28.13.tgz#68668d84924453c2baeeb0cf7d25f75b2c07e8b9"
+  integrity sha512-j1YjPl2JNHxQwQW6Bgfis44XSr4WCtdwMXr/SPpLsF1oVeTWIn3kwefcDnbuCI8Spmt1B9ab3ZLKzf2KkGN/7g==
   dependencies:
-    "@ember-data/adapter" "3.28.10"
-    "@ember-data/debug" "3.28.10"
-    "@ember-data/model" "3.28.10"
-    "@ember-data/private-build-infra" "3.28.10"
-    "@ember-data/record-data" "3.28.10"
-    "@ember-data/serializer" "3.28.10"
-    "@ember-data/store" "3.28.10"
+    "@ember-data/adapter" "3.28.13"
+    "@ember-data/debug" "3.28.13"
+    "@ember-data/model" "3.28.13"
+    "@ember-data/private-build-infra" "3.28.13"
+    "@ember-data/record-data" "3.28.13"
+    "@ember-data/serializer" "3.28.13"
+    "@ember-data/store" "3.28.13"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
     "@glimmer/env" "^0.1.7"
@@ -5765,15 +5761,7 @@ ember-element-helper@^0.6.0:
     "@embroider/macros" "^0.50.0 || ^1.0.0"
     ember-cli-babel "^7.26.6"
 
-ember-get-config@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.3.0.tgz#a73a1a87b48d9dde4c66a0e52ed5260b8a48cfbd"
-  integrity sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==
-  dependencies:
-    broccoli-file-creator "^1.1.1"
-    ember-cli-babel "^7.0.0"
-
-"ember-get-config@^1.0.2 || ^2.0.0", ember-get-config@^2.1.1:
+"ember-get-config@^1.0.2 || ^2.0.0", ember-get-config@^2.0.0, ember-get-config@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-2.1.1.tgz#bede76c25d95dbefab8d30064abf7aa00bc19235"
   integrity sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==
@@ -6630,6 +6618,11 @@ estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -11076,6 +11069,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -11909,17 +11907,6 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-node-resolve@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
-  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  dependencies:
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.11.1"
-    rollup-pluginutils "^2.8.1"
-
 rollup-pluginutils@^2.8.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -11927,19 +11914,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.12.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
-
-rollup@^2.50.0:
-  version "2.77.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.2.tgz#6b6075c55f9cc2040a5912e6e062151e42e2c4e3"
-  integrity sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==
+rollup@2.78.0, rollup@^2.50.0:
+  version "2.78.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.78.0.tgz#00995deae70c0f712ea79ad904d5f6b033209d9e"
+  integrity sha512-4+YfbQC9QEVvKTanHhIAFVUFSRsezvQF8vFOJwtGfb9Bb+r014S+qryr9PSmw8x6sMnPkmFBGAvIFVQxvJxjtg==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
## What

Add an explicit setter to the cell base's `value` computed property so Ember 4 strict-mode doesn't reject writes that propagate up from child components.

## Why

The base cell template (`addon/components/cells/base.hbs`) passes `value=this.value` into a child component (an editable input or a custom `cellComponent`). When the child writes back through the classic two-way binding, Ember 4 strict-mode now throws:

> Cannot override the computed property \`value\` on light-table/cells/base

Adding a setter makes this allowed; the cached value is invalidated again whenever `rawValue` or `column.format` change, so read semantics are preserved.

## Test plan

- [x] Existing addon tests pass locally (no behavioural change for read paths).
- [x] In a downstream consumer (`phorest/phorest-desktop-ember`) running Ember 4.12, the previously-crashing acceptance test \`marketing | added manually audience: it allows to select clients and updates counts\` now passes.